### PR TITLE
Linux layer-3 render proof: notification text OCR-verified as on-screen pixels

### DIFF
--- a/.github/workflows/toast-linux.yml
+++ b/.github/workflows/toast-linux.yml
@@ -23,8 +23,20 @@ jobs:
         with:
           node-version: 22
       - run: npm install
-      - name: Install notification daemon + tools
+      - name: Install notification daemon + capture/OCR tooling
         # fonts-dejavu-core: dunst needs a font to initialise its renderer under xvfb.
-        run: sudo apt-get update && sudo apt-get install -y dunst dbus-x11 xvfb libnotify-bin fonts-dejavu-core
-      - name: Fire a real notification and assert dunst captured it
+        # imagemagick (import/convert) + x11-apps (xwd) capture the root window;
+        # tesseract-ocr reads the rendered banner text back off the framebuffer.
+        run: sudo apt-get update && sudo apt-get install -y dunst dbus-x11 xvfb libnotify-bin fonts-dejavu-core imagemagick tesseract-ocr x11-apps
+      - name: Fire a real notification and assert dunst captured it (layer 2 — daemon record)
         run: xvfb-run -a dbus-run-session -- node scripts/live-toast-linux.mjs
+      - name: Prove it renders legible pixels on X (layer 3 — OCR-verified)
+        env:
+          RENDER_OUT: /tmp/linux-render-proof
+        run: xvfb-run -a dbus-run-session -- node scripts/live-toast-linux-render.mjs
+      - name: Upload rendered banner (proof a human can see)
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: linux-render-proof
+          path: /tmp/linux-render-proof

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ Each job runs as its own GitHub Actions workflow. The badge in every row is its 
       <td><strong>Live Toast Linux</strong></td>
       <td align="center"><a href="https://github.com/DevinoSolutions/ai-agent-notifier/actions/workflows/toast-linux.yml"><img src="https://github.com/DevinoSolutions/ai-agent-notifier/actions/workflows/toast-linux.yml/badge.svg?branch=main" alt="Toast Linux" /></a></td>
       <td>Linux</td>
-      <td>Fires through the real <code>notify-send</code> backend into a <strong>real <code>dunst</code> daemon</strong>, then reads its history and asserts it captured the exact title + body</td>
+      <td>Fires through the real <code>notify-send</code> backend into a <strong>real <code>dunst</code> daemon</strong>, then reads its history and asserts it captured the exact title + body — and goes one layer further, proving the notification is <strong>rendered on-screen</strong>: it captures the X display and reads the banner's text back with OCR (nonce present in a during-display frame, absent from the pre-fire frame) ²</td>
     </tr>
     <tr>
       <td><strong>Live Toast macOS</strong><br/>(delivery capture)</td>
@@ -424,6 +424,8 @@ Each job runs as its own GitHub Actions workflow. The badge in every row is its 
 
 ¹ The Live Codex lane completes a real `codex exec` turn, but non-interactive exec structurally can't exercise the **approval decision loop** — with no TTY, codex forces `approval: never` + a read-only sandbox, so the PermissionRequest hook never fires. That loop is proven end to end by the **TUI Proofs** lane (F2), which drives the interactive TUI. Cursor is a GUI editor (BYO key), so its lane validates the live key + real config wiring; its hook **delivery** is fully covered by the unit + e2e suites.
 
+² The on-screen render proof draws the banner with **our** tuned `dunstrc` (large mono font, high contrast) on a **virtual** X display (Xvfb), so it proves the product path renders legible, machine-readable pixels — not that every user's desktop theme renders identically. macOS has no equivalent lane: on the hosted runner a real notification records in Notification Center but never presents a banner, and the accessibility/screen-capture routes are walled off by TCC, so **layer 2 (recorded in Notification Center) is the honest macOS CI ceiling** — on-screen rendering there is a real-machine concern checked by `aan doctor --deep`. See [`docs/research/2026-07-15-layer3-render-proof.md`](docs/research/2026-07-15-layer3-render-proof.md).
+
 ### Run it yourself
 
 ```bash
@@ -434,7 +436,7 @@ npm run toast:demo  # fire real desktop toasts, every event
 
 ### The one thing CI can't prove
 
-CI goes further than "the call returned 0." On **Linux** it reads the payload back out of a real `dunst` daemon; on **macOS** it reads the delivery back out of Notification Center's own database — so a notification that was silently dropped for lack of permission records nothing and turns CI **red** instead of green. What no headless runner can prove is the last millimetre: a human's eyes actually seeing the banner render. Do Not Disturb / Focus still suppress the on-screen banner while the notification is recorded as delivered, so "reached Notification Center" is not the same as "a person saw it." To confirm with your own eyes — and to check your own machine's notification permission — run `npm run toast:demo` and `aan doctor --deep`.
+CI goes further than "the call returned 0." On **Linux** it reads the payload back out of a real `dunst` daemon **and** captures the X display to OCR the banner's text off the screen — pixels, not just a database row. On **macOS** it reads the delivery back out of Notification Center's own database — so a notification that was silently dropped for lack of permission records nothing and turns CI **red** instead of green. What no headless runner can prove is the last millimetre: a human's eyes actually seeing the banner. On macOS the on-screen banner can't be captured in CI at all (the hosted runner records the notification but never presents it, and TCC walls off the accessibility/screen-capture routes — layer 2 is the ceiling ²), and everywhere Do Not Disturb / Focus can suppress the on-screen banner while the notification is still recorded as delivered. So "reached the notification store" is not always "a person saw it." To confirm with your own eyes — and to check your own machine's notification permission — run `npm run toast:demo` and `aan doctor --deep`.
 
 ## Contributing
 

--- a/docs/research/2026-07-15-layer3-render-proof.md
+++ b/docs/research/2026-07-15-layer3-render-proof.md
@@ -1,0 +1,99 @@
+# Layer-3 render proof: proving notification text reaches the screen
+
+Date: 2026-07-15 · Status: Linux lane shipped; macOS ceiling recorded
+
+## Three layers of "the notification worked"
+
+A desktop notification can be verified at increasing depth. Each layer is a
+strictly stronger claim than the one before it:
+
+1. **Layer 1 — the call returned.** `sendToast` resolved `true` / the backend
+   exited 0. Proves we invoked the OS, not that the OS did anything. An exit-0
+   check passes even when the notification is silently dropped.
+2. **Layer 2 — the daemon recorded it.** The notification service accepted the
+   exact title + body. On Linux we read it back out of `dunst`'s history; on
+   macOS we read it out of Notification Center's own SQLite database. Proves the
+   payload reached a real notification service — a silent drop records nothing
+   and turns CI red.
+3. **Layer 3 — pixels on a display.** The notification's text was legibly drawn
+   on a screen and machine-read back off the framebuffer. This is the last
+   millimetre before "a human's eyes saw it."
+
+CI shipped layer 2 on both Linux and macOS. This note records where layer 3 is
+achievable (Linux) and where it is not (hosted macOS), so no lane overclaims.
+
+## macOS: layer 3 is NOT achievable on hosted CI (ceiling = layer 2)
+
+A throwaway spike on the `macos-15` hosted runner (Actions run **29384991828**)
+fired the real `osascript` notification and tried, three ways, to prove a banner
+drew on screen:
+
+- **Records but never presents.** The fire reliably recorded in the Notification
+  Center DB (layer 2), but no banner window ever appeared — capture frames stayed
+  bare and `CGWindowList` enumerated zero `NotificationCenter`/`usernoted`
+  windows over the banner's whole lifetime.
+- **Accessibility tree is walled off.** `System Events` → `NotificationCenter`
+  window reads returned AppleEvents error **-1728** (not permitted) — the AX
+  route is blocked by TCC on the runner.
+- **Screen capture trips a consent nag.** Repeated `screencapture` invocations
+  trip a Sequoia screen-recording consent prompt; `CGWindowList` was the only
+  TCC-light enumeration that worked, and it saw nothing.
+
+Distinguishing "a fixable presentation setting" from "the headless session never
+presents banners" would require forcing presentation *and* clearing the
+screen-recording consent wall — compounding TCC risk for uncertain payoff, since
+a forced presentation may not mirror a real user's Mac anyway.
+
+**Conclusion:** on hosted macOS CI, notifications are provable to **layer 2**
+(the shipped Toast macOS lane), not layer 3. On-screen rendering is a real-user-Mac
+concern, checked there by `aan doctor --deep` (presentation + permission state).
+
+## Linux: layer 3 IS achievable (shipped)
+
+Linux is the one surface where we own the whole session — Xvfb gives a real X
+display with no TCC equivalent, and `dunst` is a real `org.freedesktop.Notifications`
+daemon we can configure. A spike (Actions run **29391999880**, `ubuntu-latest`)
+proved the pixel read-back end to end:
+
+- Start `dunst` under a **project-owned dunstrc** tuned for OCR: DejaVu Sans Mono
+  26, white-on-black, wide banner, no timeout.
+- Fire the **real** `src/platforms/linux.mjs` → `notify-send` path with an
+  OCR-safe nonce in the body.
+- Capture the X root window with ImageMagick `import -window root` (fallback
+  `xwd | convert`) and OCR each frame with `tesseract --psm 6`.
+- **No-false-positive guard:** the pre-fire frame's OCR must not contain the
+  nonce. **Positive gate:** a during-display frame's OCR must contain it
+  (normalized, whitespace-stripped substring — never full-string equality,
+  because the icon glyph decodes to a stray leading character).
+
+Result: the nonce was legible in **6 of 6** during-display frames and absent from
+the pre-fire frame. The rendered banner PNG was inspected by a human.
+
+### What the shipped Linux lane claims (and no more)
+
+`scripts/live-toast-linux-render.mjs` runs in the **Toast Linux** workflow as a
+hard-failing step after the layer-2 history assert. Because rendering uses **our**
+dunstrc on a **virtual** (Xvfb) display, the claim is precisely: *the product path
+draws legible, machine-readable pixels* — not that every user's desktop theme
+renders identically.
+
+### Gotchas (for anyone touching this lane)
+
+- `linux.sendToast` maps `notification.priority` through `URGENCY_MAP`; it does
+  **not** read a `urgency` field. Fire with `priority`.
+- Nonce alphabet excludes `0 O 1 I L 5 S 8 B 2 Z` — the glyph pairs tesseract
+  most often confuses at banner size (`scripts/lib/ocr-nonce.mjs`).
+- Match with a normalized `.includes(nonce)`, never full-string equality: OCR
+  inserts stray whitespace and the notification icon adds a stray leading char.
+- `dunst` logs a benign `CRITICAL: Cannot acquire org.freedesktop.Notifications`
+  as the transient dbus-autolaunch instance loses the bus name to the real dunst.
+  Not a failure — delivery still works.
+- All `ubuntu` jobs on a push can queue for tens of minutes behind an
+  account-wide runner concurrency cap while macOS jobs drain; that latency is not
+  a lane failure.
+
+## References
+
+- macOS spike: Actions run `29384991828` (records to NC, no banner, AX -1728).
+- Linux spike: Actions run `29391999880` (6/6 OCR frames, human-inspected).
+- Design: `docs/specs/2026-07-15-linux-render-proof-design.md`.

--- a/docs/research/2026-07-15-layer3-render-proof.md
+++ b/docs/research/2026-07-15-layer3-render-proof.md
@@ -81,8 +81,13 @@ renders identically.
 
 - `linux.sendToast` maps `notification.priority` through `URGENCY_MAP`; it does
   **not** read a `urgency` field. Fire with `priority`.
-- Nonce alphabet excludes `0 O 1 I L 5 S 8 B 2 Z` — the glyph pairs tesseract
-  most often confuses at banner size (`scripts/lib/ocr-nonce.mjs`).
+- Nonce alphabet excludes `0 O 1 I L 5 S 8 B 2 Z` and `9` — the glyph pairs
+  tesseract most often confuses at banner size (`scripts/lib/ocr-nonce.mjs`). The
+  `9` exclusion was earned: on run `29394142374` tesseract read a rendered `9` as
+  `S`, failing the gate. The spike nonce happened to contain no `9`, so the
+  ambiguity only surfaced once the gate ran on a fresh nonce — exactly the
+  measure-flake-before-gating step the design's honesty rail calls for. Digits
+  `3 4 6 7` are each confirmed to OCR correctly on real renders.
 - Match with a normalized `.includes(nonce)`, never full-string equality: OCR
   inserts stray whitespace and the notification icon adds a stray leading char.
 - `dunst` logs a benign `CRITICAL: Cannot acquire org.freedesktop.Notifications`

--- a/docs/research/2026-07-15-layer3-render-proof.md
+++ b/docs/research/2026-07-15-layer3-render-proof.md
@@ -81,13 +81,18 @@ renders identically.
 
 - `linux.sendToast` maps `notification.priority` through `URGENCY_MAP`; it does
   **not** read a `urgency` field. Fire with `priority`.
-- Nonce alphabet excludes `0 O 1 I L 5 S 8 B 2 Z` and `9` — the glyph pairs
-  tesseract most often confuses at banner size (`scripts/lib/ocr-nonce.mjs`). The
-  `9` exclusion was earned: on run `29394142374` tesseract read a rendered `9` as
-  `S`, failing the gate. The spike nonce happened to contain no `9`, so the
-  ambiguity only surfaced once the gate ran on a fresh nonce — exactly the
-  measure-flake-before-gating step the design's honesty rail calls for. Digits
-  `3 4 6 7` are each confirmed to OCR correctly on real renders.
+- Nonce alphabet is **observed-correct glyphs only** (`scripts/lib/ocr-nonce.mjs`):
+  `ACDEGHMNPRTUVWY3467` — exactly the characters captured OCR-reading-back-correctly
+  across the three real renders (`GADNNM36RW`, `U*NRP7MY4E`, `7CNHVTVE3G`). A
+  static banner renders identical pixels every frame, so an OCR misread is
+  **systematic** — it repeats on every frame and the multi-frame retry cannot
+  rescue it. So a glyph may gate a required check only once a capture proves it
+  reads back. Excluded for two reasons: known-confusable and banned outright
+  (`0 O 1 I L 5 S 8 B 2 Z 9` — the `9` earned its place when run `29394142374`
+  read a rendered `9` as `S`, failing the gate), and not-yet-observed (`F J K Q X`,
+  held out until a capture proves them — `Q`/`O` is a classic confusable and `O`
+  is already banned). This is the measure-flake-before-gating step the design's
+  honesty rail calls for.
 - Match with a normalized `.includes(nonce)`, never full-string equality: OCR
   inserts stray whitespace and the notification icon adds a stray leading char.
 - `dunst` logs a benign `CRITICAL: Cannot acquire org.freedesktop.Notifications`

--- a/scripts/lib/ocr-nonce.mjs
+++ b/scripts/lib/ocr-nonce.mjs
@@ -5,16 +5,29 @@
 // the framebuffer with tesseract; these helpers make that read reliable and its
 // match unambiguous.
 
-// OCR-safe alphabet: excludes the glyph pairs tesseract most often confuses at
-// banner sizes — 0/O, 1/I/L, 5/S, 8/B, 2/Z, and 9 (which tesseract read as `S`
-// on a real render, Actions run 29394142374). The remaining digits 3 4 6 7 are
-// each empirically confirmed to OCR correctly at DejaVu Sans Mono 26 (runs
-// 29391999880 and 29394142374). What remains is A–Z + 3 4 6 7 after removing the
-// ambiguous glyphs.
-export const OCR_SAFE_ALPHABET = 'ACDEFGHJKMNPQRTUVWXY3467';
+// OCR-safe alphabet: OBSERVED-CORRECT GLYPHS ONLY. A static banner renders
+// identical pixels every frame, so an OCR misread is systematic — the same glyph
+// misreads on every frame and the multi-frame retry cannot rescue it. The only
+// safe policy for a gating check is therefore: a character may enter this
+// alphabet ONLY if it has been captured OCR-reading-back-correctly in a real
+// render. Add a new char only with a captured render proving it reads back.
+//
+// This set is exactly the characters observed correct across the three real
+// renders to date (GADNNM36RW, U*NRP7MY4E, 7CNHVTVE3G): A C D E G H M N P R T U
+// V W Y and 3 4 6 7. Excluded for two distinct reasons:
+//   - confusable and banned outright (OCR_EXCLUDED): 0 O 1 I L 5 S 8 B 2 Z 9;
+//   - not yet observed on a real render (F J K Q X): held out until a capture
+//     proves them — Q/O in particular is a classic confusable, and O is banned.
+export const OCR_SAFE_ALPHABET = 'ACDEGHMNPRTUVWY3467';
 
-// Characters deliberately kept OUT of the alphabet, for the no-ambiguity test.
+// Characters deliberately kept OUT of the alphabet because they are known-
+// confusable glyphs, for the no-ambiguity test.
 export const OCR_EXCLUDED = '0O1IL5S8B2Z9';
+
+// Characters held out only because they haven't been observed OCR-correct on a
+// real render yet (not confirmed confusable). Promote to OCR_SAFE_ALPHABET once
+// a captured render proves each reads back.
+export const OCR_NOT_YET_OBSERVED = 'FJKQX';
 
 // A random nonce drawn only from the OCR-safe alphabet. Default length 10 keeps
 // it short enough to fit one banner line in a large mono font, long enough that

--- a/scripts/lib/ocr-nonce.mjs
+++ b/scripts/lib/ocr-nonce.mjs
@@ -6,12 +6,15 @@
 // match unambiguous.
 
 // OCR-safe alphabet: excludes the glyph pairs tesseract most often confuses at
-// banner sizes — 0/O, 1/I/L, 5/S, 8/B, 2/Z. What remains is what's left of
-// A–Z + 2–9 after removing 0 O 1 I L 5 S 8 B 2 Z.
-export const OCR_SAFE_ALPHABET = 'ACDEFGHJKMNPQRTUVWXY34679';
+// banner sizes — 0/O, 1/I/L, 5/S, 8/B, 2/Z, and 9 (which tesseract read as `S`
+// on a real render, Actions run 29394142374). The remaining digits 3 4 6 7 are
+// each empirically confirmed to OCR correctly at DejaVu Sans Mono 26 (runs
+// 29391999880 and 29394142374). What remains is A–Z + 3 4 6 7 after removing the
+// ambiguous glyphs.
+export const OCR_SAFE_ALPHABET = 'ACDEFGHJKMNPQRTUVWXY3467';
 
 // Characters deliberately kept OUT of the alphabet, for the no-ambiguity test.
-export const OCR_EXCLUDED = '0O1IL5S8B2Z';
+export const OCR_EXCLUDED = '0O1IL5S8B2Z9';
 
 // A random nonce drawn only from the OCR-safe alphabet. Default length 10 keeps
 // it short enough to fit one banner line in a large mono font, long enough that

--- a/scripts/lib/ocr-nonce.mjs
+++ b/scripts/lib/ocr-nonce.mjs
@@ -1,0 +1,43 @@
+// scripts/lib/ocr-nonce.mjs — nonce generation + OCR normalization for the
+// Linux render proof (scripts/live-toast-linux-render.mjs). Pure logic, no I/O,
+// so the same rules are unit-testable on every OS (including Windows, where
+// tesseract is absent). The render proof reads a notification's text back off
+// the framebuffer with tesseract; these helpers make that read reliable and its
+// match unambiguous.
+
+// OCR-safe alphabet: excludes the glyph pairs tesseract most often confuses at
+// banner sizes — 0/O, 1/I/L, 5/S, 8/B, 2/Z. What remains is what's left of
+// A–Z + 2–9 after removing 0 O 1 I L 5 S 8 B 2 Z.
+export const OCR_SAFE_ALPHABET = 'ACDEFGHJKMNPQRTUVWXY34679';
+
+// Characters deliberately kept OUT of the alphabet, for the no-ambiguity test.
+export const OCR_EXCLUDED = '0O1IL5S8B2Z';
+
+// A random nonce drawn only from the OCR-safe alphabet. Default length 10 keeps
+// it short enough to fit one banner line in a large mono font, long enough that
+// it can't collide with incidental on-screen text.
+export function generateNonce(length = 10) {
+  let s = '';
+  for (let i = 0; i < length; i++) {
+    s += OCR_SAFE_ALPHABET[Math.floor(Math.random() * OCR_SAFE_ALPHABET.length)];
+  }
+  return s;
+}
+
+// Normalize an OCR result for comparison: strip ALL whitespace and uppercase.
+// tesseract sprinkles stray spaces/newlines inside and around a banner (and the
+// notification icon glyph often decodes to a stray leading character), so a
+// whitespace-insensitive substring test is the only reliable match — never a
+// full-string equality compare against the raw OCR.
+export function normalizeOcr(text) {
+  return String(text || '').replace(/\s+/g, '').toUpperCase();
+}
+
+// Does the OCR text contain the nonce, after normalizing both sides? This is the
+// positive gate and the no-false-positive guard both. Because the alphabet is
+// uppercase-only and normalize() uppercases, this is case-insensitive.
+export function ocrContainsNonce(ocrText, nonce) {
+  const n = normalizeOcr(nonce);
+  if (!n) return false;
+  return normalizeOcr(ocrText).includes(n);
+}

--- a/scripts/live-toast-linux-render.mjs
+++ b/scripts/live-toast-linux-render.mjs
@@ -1,0 +1,193 @@
+// scripts/live-toast-linux-render.mjs — LAYER-3 render proof on Linux.
+//
+// The sibling scripts/live-toast-linux.mjs proves the daemon *recorded* our
+// exact title + body (layer 2). This goes one layer further: it proves the
+// notification's text was legibly DRAWN AS PIXELS on a real X display and read
+// back off the framebuffer. It starts dunst under a spike-tuned, PROJECT-OWNED
+// dunstrc (large mono font, high contrast, no timeout) on a virtual display,
+// fires the REAL Linux backend (src/platforms/linux.mjs → notify-send), captures
+// the root window, and OCRs it with tesseract:
+//   - no-false-positive guard: the PRE-fire frame must NOT contain the nonce;
+//   - positive gate: a DURING-display frame MUST contain the nonce.
+// Both are hard failures. The passing banner PNG is saved for artifact upload so
+// a human can see the rendered notification.
+//
+// Because rendering uses OUR dunstrc on a virtual (Xvfb) display, this proves
+// the product path draws readable pixels — not that every user's desktop theme
+// renders identically.
+//
+// Must run with a session bus and a display, e.g. in CI:
+//   xvfb-run -a dbus-run-session -- node scripts/live-toast-linux-render.mjs
+//
+// Requires: dunst, dbus-x11, xvfb, libnotify-bin, fonts-dejavu-core,
+//           imagemagick (import/convert), tesseract-ocr, x11-apps (xwd fallback).
+import os from 'node:os';
+import { spawn, spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync, copyFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { sendToast } from '../src/platforms/linux.mjs';
+import { generateNonce, ocrContainsNonce } from './lib/ocr-nonce.mjs';
+
+const OUT = process.env.RENDER_OUT || '/tmp/linux-render-proof';
+const BANNER_PNG = path.join(OUT, 'render-banner.png');
+
+const sh = (cmd, args, opts = {}) => spawnSync(cmd, args, { encoding: 'utf8', ...opts });
+const pad = (n) => String(n).padStart(2, '0');
+
+function fail(msg) {
+  console.error(`FAIL: ${msg}`);
+  process.exit(1);
+}
+
+// A project-owned dunstrc tuned for OCR: big mono font, no expiry, wide banner,
+// white-on-black, anchored top-right. This is OUR config on a virtual display —
+// the claim is "the product path draws readable pixels", not "every theme does".
+function writeDunstrc() {
+  const rc = `[global]
+    font = DejaVu Sans Mono 26
+    frame_width = 3
+    frame_color = "#FFFFFF"
+    separator_color = frame
+    sort = no
+    idle_threshold = 0
+    origin = top-right
+    offset = 20x40
+    width = 640
+    height = 400
+    notification_limit = 0
+    padding = 24
+    horizontal_padding = 24
+    line_height = 4
+    markup = no
+    format = "%s\\n%b"
+    alignment = left
+    show_age_threshold = -1
+    word_wrap = yes
+    ignore_newline = no
+    stack_duplicates = false
+    show_indicators = no
+    transparency = 0
+    corner_radius = 0
+
+[urgency_low]
+    background = "#000000"
+    foreground = "#FFFFFF"
+    timeout = 0
+
+[urgency_normal]
+    background = "#000000"
+    foreground = "#FFFFFF"
+    timeout = 0
+
+[urgency_critical]
+    background = "#000000"
+    foreground = "#FFFFFF"
+    timeout = 0
+`;
+  const p = path.join(OUT, 'dunstrc');
+  writeFileSync(p, rc);
+  return p;
+}
+
+// Capture the X root window to a PNG. Prefer ImageMagick `import`; fall back to
+// `xwd | convert`. DISPLAY comes from xvfb-run's env.
+function capture(file) {
+  const disp = process.env.DISPLAY || ':99';
+  const imp = sh('import', ['-window', 'root', '-display', disp, file], { timeout: 8000 });
+  if (imp.status === 0 && existsSync(file)) return true;
+  const xwd = sh('bash', ['-lc', `xwd -root -display ${disp} | convert xwd:- ${file}`], { timeout: 8000 });
+  return xwd.status === 0 && existsSync(file);
+}
+
+// OCR a PNG with tesseract; --psm 6 = assume a uniform block of text.
+function ocr(file) {
+  const r = sh('tesseract', [file, 'stdout', '--psm', '6'], { timeout: 15000 });
+  if (r.status === 0) return r.stdout || '';
+  const r2 = sh('tesseract', [file, 'stdout'], { timeout: 15000 });
+  return r2.status === 0 ? (r2.stdout || '') : '';
+}
+
+async function main() {
+  if (os.platform() !== 'linux') fail('render proof is Linux-only.');
+  if (!process.env.DBUS_SESSION_BUS_ADDRESS) {
+    fail('no DBUS_SESSION_BUS_ADDRESS — run under `dbus-run-session`.');
+  }
+  if (!process.env.DISPLAY) fail('no DISPLAY — run under `xvfb-run`.');
+
+  mkdirSync(OUT, { recursive: true });
+  const nonce = generateNonce();
+  writeFileSync(path.join(OUT, 'nonce.txt'), nonce);
+  console.log(`render-proof nonce=${nonce} DISPLAY=${process.env.DISPLAY}`);
+
+  const rcPath = writeDunstrc();
+  const dunst = spawn('dunst', ['-config', rcPath], { stdio: 'ignore' });
+  dunst.on('error', (err) => fail(`could not start dunst: ${err.message}`));
+
+  // Wait for dunst to own org.freedesktop.Notifications (dunstctl succeeds once
+  // it's up). dunst logs a benign "Cannot acquire ..." line as the transient
+  // dbus autolaunch instance loses the name to the real dunst — not a failure.
+  let ready = false;
+  for (let i = 0; i < 40; i++) {
+    if (sh('dunstctl', ['is-paused']).status === 0) { ready = true; break; }
+    await sleep(250);
+  }
+  if (!ready) { dunst.kill(); fail('dunst did not become ready within 10s.'); }
+  console.log('dunst is up and owns org.freedesktop.Notifications');
+
+  // --- No-false-positive guard: pre-fire frame must NOT contain the nonce. ---
+  const preFile = path.join(OUT, 'frame-pre.png');
+  if (!capture(preFile)) { dunst.kill(); fail('could not capture the pre-fire frame.'); }
+  const preOcr = ocr(preFile);
+  writeFileSync(path.join(OUT, 'frame-pre.txt'), preOcr);
+  if (ocrContainsNonce(preOcr, nonce)) {
+    dunst.kill();
+    fail(`nonce ${nonce} already present in the pre-fire frame — capture/OCR is not trustworthy.`);
+  }
+  console.log('pre-fire guard passed: nonce absent before firing');
+
+  // --- Fire the REAL product backend. linux.sendToast keys off `priority`
+  // (mapped through URGENCY_MAP), not `urgency`. ---
+  const notification = {
+    title: 'AI Agent Notifier',
+    message: `RENDER ${nonce}`,
+    priority: 'high',
+    source: 'claude',
+  };
+  const delivered = await sendToast(notification);
+  if (!delivered) { dunst.kill(); fail('linux sendToast returned false (notify-send did not exit 0).'); }
+  console.log(`fired via notify-send: "${notification.title}" / "${notification.message}"`);
+
+  // --- Positive gate: a during-display frame MUST contain the nonce. Retry a
+  // handful of frames over ~5s to absorb render/capture timing. ---
+  const N = 8;
+  let hitFrame = null;
+  for (let i = 0; i < N; i++) {
+    await sleep(600);
+    const f = path.join(OUT, `frame-${pad(i)}.png`);
+    if (!capture(f)) { console.log(`frame ${pad(i)}: capture failed`); continue; }
+    const text = ocr(f);
+    writeFileSync(path.join(OUT, `frame-${pad(i)}.txt`), text);
+    const hit = ocrContainsNonce(text, nonce);
+    console.log(`frame ${pad(i)}: nonceHit=${hit}`);
+    if (hit) { hitFrame = f; break; }
+  }
+
+  // Move any displayed notification into history for the artifact record.
+  sh('dunstctl', ['close-all']);
+  const hist = sh('dunstctl', ['history']);
+  writeFileSync(path.join(OUT, 'dunst-history.json'), hist.stdout || hist.stderr || '(no output)');
+
+  dunst.kill();
+
+  if (!hitFrame) {
+    fail(`nonce ${nonce} never appeared in any during-display frame's OCR — the banner did not render legibly.`);
+  }
+
+  copyFileSync(hitFrame, BANNER_PNG);
+  console.log(`PASS (hard): notification text rendered as legible pixels on X — nonce ${nonce} OCR-read from ${path.basename(hitFrame)}`);
+  console.log(`banner saved to ${BANNER_PNG}`);
+  process.exit(0);
+}
+
+main().catch((e) => fail(e && e.stack ? e.stack : String(e)));

--- a/tests/ocr-nonce.test.mjs
+++ b/tests/ocr-nonce.test.mjs
@@ -9,13 +9,21 @@ import assert from 'node:assert/strict';
 import {
   OCR_SAFE_ALPHABET,
   OCR_EXCLUDED,
+  OCR_NOT_YET_OBSERVED,
   generateNonce,
   normalizeOcr,
   ocrContainsNonce,
 } from '../scripts/lib/ocr-nonce.mjs';
 
-describe('OCR_SAFE_ALPHABET — excludes ambiguous glyphs', () => {
-  it('contains none of the excluded characters 0 O 1 I L 5 S 8 B 2 Z 9', () => {
+describe('OCR_SAFE_ALPHABET — observed-correct glyphs only', () => {
+  it('is exactly the set observed OCR-correct on real renders', () => {
+    // Pinning the exact string enforces the policy: a char enters only with a
+    // captured render proving it reads back. Changing this without such a
+    // capture should break this test on purpose.
+    assert.equal(OCR_SAFE_ALPHABET, 'ACDEGHMNPRTUVWY3467');
+  });
+
+  it('contains none of the known-confusable characters 0 O 1 I L 5 S 8 B 2 Z 9', () => {
     for (const ch of OCR_EXCLUDED) {
       assert.ok(!OCR_SAFE_ALPHABET.includes(ch), `alphabet must not contain "${ch}"`);
     }
@@ -23,6 +31,15 @@ describe('OCR_SAFE_ALPHABET — excludes ambiguous glyphs', () => {
 
   it('excludes 9 specifically (tesseract read it as S on a real render)', () => {
     assert.ok(!OCR_SAFE_ALPHABET.includes('9'), 'alphabet must not contain "9"');
+  });
+
+  it('excludes F J K Q X — not yet observed OCR-correct on a real render', () => {
+    // These are held out because no capture has proven them (not because they
+    // are known-confusable). A static banner misreads systematically, so an
+    // unverified glyph is an unacceptable random-red risk on a gating check.
+    for (const ch of OCR_NOT_YET_OBSERVED) {
+      assert.ok(!OCR_SAFE_ALPHABET.includes(ch), `alphabet must not contain unobserved "${ch}"`);
+    }
   });
 
   it('is drawn only from uppercase letters and the confirmed-safe digits 3 4 6 7', () => {

--- a/tests/ocr-nonce.test.mjs
+++ b/tests/ocr-nonce.test.mjs
@@ -1,0 +1,105 @@
+// tests/ocr-nonce.test.mjs — strict, pure-logic tests for the render-proof nonce
+// helpers. No tesseract, no display, no I/O — so these pass identically on
+// Windows (where the Linux render proof itself can't run). They pin the three
+// properties the proof depends on: the alphabet excludes OCR-ambiguous glyphs,
+// normalization is whitespace-insensitive + uppercasing, and matching is a
+// normalized substring test (never full-string equality).
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  OCR_SAFE_ALPHABET,
+  OCR_EXCLUDED,
+  generateNonce,
+  normalizeOcr,
+  ocrContainsNonce,
+} from '../scripts/lib/ocr-nonce.mjs';
+
+describe('OCR_SAFE_ALPHABET — excludes ambiguous glyphs', () => {
+  it('contains none of the excluded characters 0 O 1 I L 5 S 8 B 2 Z', () => {
+    for (const ch of OCR_EXCLUDED) {
+      assert.ok(!OCR_SAFE_ALPHABET.includes(ch), `alphabet must not contain "${ch}"`);
+    }
+  });
+
+  it('is a subset of A-Z plus 3-9 (uppercase letters and digits only)', () => {
+    assert.match(OCR_SAFE_ALPHABET, /^[A-Z3-9]+$/);
+  });
+
+  it('has no duplicate characters', () => {
+    assert.equal(new Set(OCR_SAFE_ALPHABET).size, OCR_SAFE_ALPHABET.length);
+  });
+});
+
+describe('generateNonce', () => {
+  it('defaults to length 10', () => {
+    assert.equal(generateNonce().length, 10);
+  });
+
+  it('honors an explicit length', () => {
+    assert.equal(generateNonce(16).length, 16);
+  });
+
+  it('only ever draws characters from the OCR-safe alphabet', () => {
+    for (let i = 0; i < 200; i++) {
+      const nonce = generateNonce();
+      for (const ch of nonce) {
+        assert.ok(OCR_SAFE_ALPHABET.includes(ch), `nonce char "${ch}" not in OCR-safe alphabet`);
+      }
+    }
+  });
+
+  it('never emits an excluded character across many draws', () => {
+    for (let i = 0; i < 200; i++) {
+      const nonce = generateNonce(12);
+      for (const ch of OCR_EXCLUDED) {
+        assert.ok(!nonce.includes(ch), `nonce leaked excluded char "${ch}"`);
+      }
+    }
+  });
+});
+
+describe('normalizeOcr', () => {
+  it('strips all whitespace (spaces, tabs, newlines)', () => {
+    assert.equal(normalizeOcr('AB CD\tEF\nGH'), 'ABCDEFGH');
+  });
+
+  it('uppercases lowercase input', () => {
+    assert.equal(normalizeOcr('render gadnnm36rw'), 'RENDERGADNNM36RW');
+  });
+
+  it('returns empty string for null/undefined/empty', () => {
+    assert.equal(normalizeOcr(null), '');
+    assert.equal(normalizeOcr(undefined), '');
+    assert.equal(normalizeOcr(''), '');
+  });
+});
+
+describe('ocrContainsNonce — the render-proof gate', () => {
+  it('matches when the nonce sits inside surrounding banner text', () => {
+    // Mirrors real tesseract output: a stray icon-glyph char, the title line,
+    // then the body line carrying the nonce.
+    const ocr = 'g AI Agent Notifier\nRENDER GADNNM36RW\n';
+    assert.equal(ocrContainsNonce(ocr, 'GADNNM36RW'), true);
+  });
+
+  it('matches across OCR-inserted whitespace inside the nonce', () => {
+    assert.equal(ocrContainsNonce('RENDER GAD NNM 36RW', 'GADNNM36RW'), true);
+  });
+
+  it('is case-insensitive', () => {
+    assert.equal(ocrContainsNonce('render gadnnm36rw', 'GADNNM36RW'), true);
+  });
+
+  it('does NOT match a blank pre-fire frame (no-false-positive guard)', () => {
+    assert.equal(ocrContainsNonce('', 'GADNNM36RW'), false);
+    assert.equal(ocrContainsNonce('\n \t\n', 'GADNNM36RW'), false);
+  });
+
+  it('does NOT match a different nonce', () => {
+    assert.equal(ocrContainsNonce('RENDER ACDEFGHJKM', 'GADNNM36RW'), false);
+  });
+
+  it('does NOT match when the nonce is empty (guards against vacuous truth)', () => {
+    assert.equal(ocrContainsNonce('anything at all', ''), false);
+  });
+});

--- a/tests/ocr-nonce.test.mjs
+++ b/tests/ocr-nonce.test.mjs
@@ -15,14 +15,18 @@ import {
 } from '../scripts/lib/ocr-nonce.mjs';
 
 describe('OCR_SAFE_ALPHABET — excludes ambiguous glyphs', () => {
-  it('contains none of the excluded characters 0 O 1 I L 5 S 8 B 2 Z', () => {
+  it('contains none of the excluded characters 0 O 1 I L 5 S 8 B 2 Z 9', () => {
     for (const ch of OCR_EXCLUDED) {
       assert.ok(!OCR_SAFE_ALPHABET.includes(ch), `alphabet must not contain "${ch}"`);
     }
   });
 
-  it('is a subset of A-Z plus 3-9 (uppercase letters and digits only)', () => {
-    assert.match(OCR_SAFE_ALPHABET, /^[A-Z3-9]+$/);
+  it('excludes 9 specifically (tesseract read it as S on a real render)', () => {
+    assert.ok(!OCR_SAFE_ALPHABET.includes('9'), 'alphabet must not contain "9"');
+  });
+
+  it('is drawn only from uppercase letters and the confirmed-safe digits 3 4 6 7', () => {
+    assert.match(OCR_SAFE_ALPHABET, /^[A-Z3467]+$/);
   });
 
   it('has no duplicate characters', () => {


### PR DESCRIPTION
## What this proves

The **Toast Linux** lane already proved **layer 2**: a real `dunst` daemon *recorded* our exact title + body. This adds **layer 3** — the notification's text is **legibly rendered as pixels on a real X display** and read back off the framebuffer with OCR.

New hard-failing step in the same job:
- Starts `dunst` under a **project-owned dunstrc** (DejaVu Sans Mono 26, white-on-black, no timeout) on the Xvfb display.
- Fires the **real** `src/platforms/linux.mjs` → `notify-send` path with an OCR-safe nonce.
- Captures the X root window (ImageMagick `import`, `xwd|convert` fallback) and OCRs each frame (`tesseract --psm 6`).
- **No-false-positive guard:** pre-fire frame's OCR must NOT contain the nonce (hard-fail).
- **Positive gate:** a during-display frame's OCR MUST contain the nonce, normalized substring match, retried over ~5s (hard-fail).
- Uploads the passing banner PNG as artifact `linux-render-proof` so a human can see it.

The existing layer-2 `dunstctl history` assert (`scripts/live-toast-linux.mjs`) is **unchanged** and still runs first.

## Before vs after

| | Before | After |
|---|---|---|
| Linux | daemon *recorded* exact title+body (layer 2) | + banner text *rendered on-screen*, OCR-verified (layer 3) |
| macOS | NC DB recorded (layer 2) | unchanged — layer 2 is the honest ceiling |

## macOS ceiling (recorded, not regressed)

Hosted `macos-15` can't prove layer 3: a real notification records in Notification Center but never presents a banner, and the accessibility/screen-capture routes are walled off by TCC (spike run 29384991828 — AX error -1728, `screencapture` consent nag, `CGWindowList` sees no banner window). So **layer 2 is the macOS CI ceiling**; on-screen rendering there is a real-machine concern checked by `aan doctor --deep`. Written up in `docs/research/2026-07-15-layer3-render-proof.md`.

## Honest scope

The render proof draws the banner with **our** tuned dunstrc on a **virtual** (Xvfb) display. The claim is precisely: *the product path draws legible, machine-readable pixels* — **not** that every user's desktop theme renders identically. README row + footnote ² and the research doc state this explicitly.

## Evidence

Proven end to end by spike run **29391999880** (`ubuntu-latest`): nonce legible in **6/6** during-display frames, absent from the pre-fire frame; banner PNG human-inspected. Pure-logic helpers (`scripts/lib/ocr-nonce.mjs`) have **16 unit tests** (`tests/ocr-nonce.test.mjs`) that pass on Windows where tesseract is absent. `npm test` green locally (276 pass / 0 fail).

## Spike cleanup

The throwaway spike files (`scripts/spike/`, `.github/workflows/render-proof-spike.yml`) live only on `spike/render-proof`, never on `main`, so there is nothing to delete in this branch. That branch stays as the spike record until this merges.
