### PR TITLE
fix: final audit pass — 2 bugs, honest claims, install bootstrappers, CI dedupe, release rails (1.2.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Desktop & phone notifications for AI coding agents in VS Code and CLI",
-    "version": "1.2.0"
+    "version": "1.2.1"
   },
   "plugins": [{
     "name": "ai-agent-notifier",
     "source": "./",
     "description": "Desktop & phone notifications for AI coding agents. Supports Claude Code, Codex, Gemini CLI, and Cursor with toast alerts and ntfy push.",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "author": { "name": "DevinoSolutions" },
     "repository": "https://github.com/DevinoSolutions/ai-agent-notifier",
     "license": "AGPL-3.0-or-later",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-agent-notifier",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Desktop & phone notifications for AI coding agents in VS Code and CLI. Supports Claude Code, Codex, Gemini CLI, and Cursor.",
   "author": {
     "name": "DevinoSolutions",

--- a/.github/workflows/agents.yml
+++ b/.github/workflows/agents.yml
@@ -2,7 +2,10 @@ name: Agents
 
 on:
   push:
+    branches: [main]
+    paths-ignore: ['**/*.md', 'docs/**', 'LICENSE', '.gitignore']
   pull_request:
+    paths-ignore: ['**/*.md', 'docs/**', 'LICENSE', '.gitignore']
 
 concurrency:
   group: '${{ github.workflow }}-${{ github.ref }}'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,6 +2,7 @@ name: E2E
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Release
+
+# Publishes to npm + drafts a GitHub release when a semver tag is pushed.
+# CI never tags itself — the maintainer cuts the release:
+#   npm version <patch|minor|major>   # bumps package.json + syncs plugin manifests
+#   git push && git push --tags       # the tag push triggers THIS workflow
+# Requires the NPM_TOKEN repo secret (an npm automation token with publish rights).
+on:
+  push:
+    tags: ['v*']
+
+concurrency:
+  group: 'release-${{ github.ref }}'
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Unit (${{ matrix.os }}, node ${{ matrix.node }})
+    # Same 3-OS × node 18/20/22 gate as unit.yml. npm test also runs the
+    # unit-safe toast tests (tests/platforms.test.mjs); the live fire paths there
+    # are gated behind AAN_TOAST_LIVE, which we deliberately do NOT set — so this
+    # is the non-live sanity for the toast backends, no daemon/desktop required.
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node: [18, 20, 22]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm install
+      - name: Unit + integration tests
+        run: npm test
+        env:
+          AAN_SENTRY_TEST_DSN: ${{ secrets.AAN_SENTRY_TEST_DSN }}
+
+  verify-payload:
+    name: Verify tag/version match + npm payload
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+      - run: npm install
+      - name: Tag must match package.json version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG="$(node -p "require('./package.json').version")"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "FAIL: tag v$TAG does not match package.json version $PKG"; exit 1
+          fi
+          echo "tag and package.json agree on $PKG"
+      - name: Plugin manifests must be in lockstep with package.json
+        # idempotent; exits 1 if a manifest is missing or drifted from package.json
+        run: |
+          node scripts/sync-plugin-version.mjs
+          git diff --exit-code .claude-plugin || {
+            echo "FAIL: plugin manifests are not synced to package.json — run 'npm version' before tagging"; exit 1;
+          }
+      - name: Pack dry-run — list the exact files that will ship
+        run: npm pack --dry-run
+
+  publish:
+    name: Publish to npm (provenance) + GitHub release
+    needs: [test, verify-payload]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the GitHub release
+      id-token: write # npm provenance attestation (Sigstore / OIDC)
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+      - name: Publish to npm with provenance
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Create GitHub release with generated notes
+        run: gh release create "$GITHUB_REF_NAME" --verify-tag --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/toast-linux.yml
+++ b/.github/workflows/toast-linux.yml
@@ -5,6 +5,7 @@ name: Toast Linux
 # title + body. Headless CI can't prove a human SAW it — see `npm run toast:demo`.
 on:
   push:
+    branches: [main]
     paths-ignore: ['**/*.md', 'docs/**', 'LICENSE', '.gitignore']
   pull_request:
     paths-ignore: ['**/*.md', 'docs/**', 'LICENSE', '.gitignore']

--- a/.github/workflows/toast-macos.yml
+++ b/.github/workflows/toast-macos.yml
@@ -5,6 +5,7 @@ name: Toast macOS
 # an exit-code check, this fails when a real user would have seen nothing.
 on:
   push:
+    branches: [main]
     paths-ignore: ['**/*.md', 'docs/**', 'LICENSE', '.gitignore']
   pull_request:
     paths-ignore: ['**/*.md', 'docs/**', 'LICENSE', '.gitignore']

--- a/.github/workflows/toast-native.yml
+++ b/.github/workflows/toast-native.yml
@@ -7,6 +7,7 @@ name: Toast Native
 # lane (Notification Center DB capture).
 on:
   push:
+    branches: [main]
     paths-ignore: ['**/*.md', 'docs/**', 'LICENSE', '.gitignore']
   pull_request:
     paths-ignore: ['**/*.md', 'docs/**', 'LICENSE', '.gitignore']

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -2,6 +2,7 @@ name: Unit
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 concurrency:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ That's it. The setup wizard detects your platform and installed AI tools, wires 
 ## Features
 
 - **Desktop toast notifications** -- Windows (BurntToast), macOS (Notification Center), Linux (libnotify)
-- **WSL-native toasts** -- real Windows toast notifications from inside WSL, no Linux notification daemon needed
+- **WSL toast routing** -- toasts from inside WSL are routed to Windows over PowerShell interop instead of a Linux notification daemon (see the proof boundary below)
 - **Phone push notifications** -- Android & iOS via [ntfy](https://ntfy.sh) (free, no account required)
 - **Webhook notifications** -- Slack, Discord, Telegram, or any HTTP endpoint, with an optional auth header
 - **Rich notification content** -- Claude Code toasts and webhooks show what the agent actually said or asked, not a generic line
@@ -304,7 +304,6 @@ Hook fires (stdin JSON + --source flag)
 ### macOS
 
 - Uses built-in `osascript` -- zero additional dependencies
-- Falls back to `terminal-notifier` for richer features if available
 
 ### Linux
 
@@ -314,9 +313,10 @@ Hook fires (stdin JSON + --source flag)
 ### WSL
 
 - Auto-detected -- no config needed
-- Toast notifications route to a real Windows toast via PowerShell interop (`powershell.exe`/`pwsh.exe` across the `/mnt/c` boundary), not `notify-send`/D-Bus
+- Toast notifications are routed to Windows via PowerShell interop (`powershell.exe`/`pwsh.exe` across the `/mnt/c` boundary) instead of `notify-send`/D-Bus, so no Linux notification daemon is needed
 - Needs WSL2 interop enabled and a Windows PowerShell present -- both are on by default
 - Terminal bell and ntfy behave exactly as on native Linux
+- **Proof boundary:** WSL detection and the interop invocation are unit-tested (`tests/platforms-wsl.test.mjs`), but — unlike the native Linux/macOS/Windows toast lanes — no hosted CI runner proves a toast reaches the Windows host end to end, so this path is not claimed in the Testing table below
 
 ## Requirements
 
@@ -427,6 +427,8 @@ Each job runs as its own GitHub Actions workflow. The badge in every row is its 
 ² The on-screen render proof draws the banner with **our** tuned `dunstrc` (large mono font, high contrast) on a **virtual** X display (Xvfb), so it proves the product path renders legible, machine-readable pixels — not that every user's desktop theme renders identically. macOS has no equivalent lane: on the hosted runner a real notification records in Notification Center but never presents a banner, and the accessibility/screen-capture routes are walled off by TCC, so **layer 2 (recorded in Notification Center) is the honest macOS CI ceiling** — on-screen rendering there is a real-machine concern checked by `aan doctor --deep`. See [`docs/research/2026-07-15-layer3-render-proof.md`](docs/research/2026-07-15-layer3-render-proof.md).
 
 ³ Like macOS, Windows is proven to **layer 2** in CI: the hosted `windows-latest` runner is a headless Session-0 environment with no interactive desktop, so the toast is **recorded** by the Windows notification platform but no banner is presented on a screen. The gate reads the record back out of `wpndatabase.db` (WAL-aware — a freshly fired toast lives in the DB's write-ahead log, so an `immutable=1` open would miss it and falsely report absence) and asserts the exact nonce in the title and body. On-screen rendering is a real-machine concern checked by `aan doctor` (PowerShell + BurntToast + execution-policy state). See [`docs/research/2026-07-15-layer3-render-proof.md`](docs/research/2026-07-15-layer3-render-proof.md).
+
+**WSL** has no row above on purpose. WSL toast routing (PowerShell interop across the `/mnt/c` boundary) is unit-tested for detection and interop invocation (`tests/platforms-wsl.test.mjs`, fully deps-injected), but a hosted CI runner cannot host both a WSL guest and an interactive Windows desktop to prove a toast crosses the boundary and lands — so, matching how the Codex `exec` lane doesn't claim the approval-decision loop (¹), that end-to-end delivery is deliberately **not** asserted here.
 
 ### Run it yourself
 

--- a/cli/doctor-checks.mjs
+++ b/cli/doctor-checks.mjs
@@ -170,6 +170,11 @@ export async function runChecks({ config, configProblem = null, deep = false, st
   if (p === 'darwin') {
     try { results.push(await toastAuthCheck(deep, strict)); }
     catch (err) { results.push({ id: 'toast-auth', channel: 'toast', status: 'warn', detail: `auth check errored: ${err.message}` }); }
+  } else if (deep) {
+    // --deep's only real probe is the macOS NC read-back; on linux/win32 it would
+    // otherwise silently no-op, so say so explicitly (Linux daemon read-back is a
+    // deferred follow-up — see docs/audits/2026-07-16-final-pass.json, TC-27).
+    results.push({ id: 'deep-probe', channel: 'toast', status: 'info', detail: `deep verification not available on ${p} (static checks only)` });
   }
   results.push(bellCheck(), ntfyCheck(config), webhookCheck(config), configCheck(config, configProblem));
   if (p === 'darwin') results.push(focusCheck());

--- a/cli/doctor.mjs
+++ b/cli/doctor.mjs
@@ -7,7 +7,7 @@ import { loadConfigResult } from '../src/config-loader.mjs';
 import { runChecks } from './doctor-checks.mjs';
 import { c } from './ui.mjs';
 
-const ICON = { ok: c.success('✓'), warn: c.warn('⚠'), fail: c.error('✗') };
+const ICON = { ok: c.success('✓'), warn: c.warn('⚠'), fail: c.error('✗'), info: c.accent('ℹ') };
 
 export async function run(...args) {
   const flags = new Set(args.filter(Boolean));

--- a/cli/test.mjs
+++ b/cli/test.mjs
@@ -6,7 +6,18 @@ import { resolveToastBackend } from '../src/platforms/index.mjs';
 import { sendBell } from '../src/bell.mjs';
 import { c, spinner } from './ui.mjs';
 
+// The channels `test` understands. Omitting the arg runs all applicable ones;
+// `both` is the documented toast+ntfy shorthand. An unrecognised value used to
+// print the header and exit 0 doing nothing, which reads as a silent success.
+export const KNOWN_CHANNELS = ['toast', 'ntfy', 'webhook', 'bell', 'both'];
+
 export async function run(channel) {
+  if (channel && !KNOWN_CHANNELS.includes(channel)) {
+    console.error(`  ${c.error('Unknown channel:')} ${channel} ${c.muted(`(valid: ${KNOWN_CHANNELS.join(', ')})`)}`);
+    process.exitCode = 1;
+    return;
+  }
+
   const { config, problem } = loadConfigResult();
   if (problem) {
     console.error(`  ${c.error('Config error:')} ${problem.message}`);

--- a/cli/update-check.mjs
+++ b/cli/update-check.mjs
@@ -50,8 +50,23 @@ function writeCache(cachePath, data) {
   } catch { /* cache is best-effort — a write failure just re-checks next run */ }
 }
 
+// True when `a` is a strictly newer semver than `b` (field-by-field numeric
+// compare, so 1.10.0 > 1.9.0 — a plain string `!==` would also fire when the
+// local build is AHEAD of npm's latest and nag users to "update" to an older
+// version). Pre-release/build metadata is ignored; anything unparseable is
+// treated as not-newer, so the check stays quiet rather than nagging wrongly.
+export function isNewer(a, b) {
+  const parse = (v) => String(v).split('-')[0].split('.').map((n) => parseInt(n, 10) || 0);
+  const [pa, pb] = [parse(a), parse(b)];
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] || 0) !== (pb[i] || 0)) return (pa[i] || 0) > (pb[i] || 0);
+  }
+  return false;
+}
+
 // Query npm for the published 'latest' version. Resolves to the version string
-// when it differs from ours (an update is available), else null. Never throws.
+// only when it is strictly newer than ours (an update is available), else null.
+// Never throws.
 export function fetchLatest() {
   return new Promise((resolve) => {
     const req = https.get('https://registry.npmjs.org/ai-agent-notifier/latest', { timeout: 3000 }, (res) => {
@@ -60,7 +75,7 @@ export function fetchLatest() {
       res.on('end', () => {
         try {
           const latest = JSON.parse(data).version;
-          resolve(latest && latest !== pkg.version ? latest : null);
+          resolve(latest && isNewer(latest, pkg.version) ? latest : null);
         } catch { resolve(null); }
       });
     });

--- a/docs/audits/2026-07-16-final-pass.json
+++ b/docs/audits/2026-07-16-final-pass.json
@@ -1,0 +1,246 @@
+{
+  "pass": 3,
+  "date": "2026-07-16",
+  "auditor": "Claude Fable 5 + Opus remediation subagent, two-lens audit (runtime/cli + docs/ci/release)",
+  "scope": "Final audit-and-improvement pass over ai-agent-notifier: two verified runtime bugs, honesty of the user-facing README, real install bootstrappers, doctor --deep candor, CI double-run economics, small CLI/runtime correctness fixes, and the missing npm release pipeline. Reinstates the docs/audits/ convention that lapsed while demand passes 3-5 (PRs #5-#8) shipped without records.",
+  "verification_summary": {
+    "checks_passed": [
+      "npm test — full unit + integration suite green locally on Windows (308 tests, 300 pass, 8 platform-skipped, 0 fail), including all new regression tests",
+      "linux buildNotifySendArgs: options precede the `--` guard; a leading-dash message lands after `--` (tests/platforms.test.mjs)",
+      "sendNtfy resolves false (never throws) on a scheme-less server typo (tests/ntfy-send.test.mjs)",
+      "config-loader rejects a control-char (newline) source label and non-string label/icon, keeps clean custom values (tests/config-loader-validation.test.mjs)",
+      "cli test <unknown-channel> exits 1 naming the valid set (tests/cli-test.test.mjs)",
+      "doctor --deep on a non-darwin platform emits an explicit 'not available' info line (tests/doctor.test.mjs)",
+      "isNewer semver gate: true only when strictly newer; 1.0.6 vs local 1.2.1 stays quiet (tests/update-check.test.mjs)",
+      "npm version 1.2.1 --no-git-tag-version synced package.json + plugin.json + marketplace.json to 1.2.1 with no tag created"
+    ],
+    "checks_failed": [],
+    "blocked": [
+      "npm publish of v1.2.1 — requires the maintainer to add the NPM_TOKEN repo secret and push a v1.2.1 tag; CI must never publish or tag itself (release.yml is the rail, deliberately un-triggered)",
+      "Real WSL toast-to-Windows-host delivery — not provable on a hosted GitHub runner (cannot host a WSL guest and an interactive Windows desktop together); documented as a proof boundary instead",
+      "Linux doctor --deep daemon read-back — deferred follow-up; needs a notification-daemon history probe not built this pass"
+    ]
+  },
+  "findings": [
+    {
+      "id": "RT-16",
+      "title": "Linux notify-send called with positionals before the `--` end-of-options guard",
+      "severity": "medium",
+      "area": "toast-delivery",
+      "evidence": "src/platforms/linux.mjs:27-31 — args were [title, message, '--urgency', level] with no `--`. GLib GOption parses any pre-`--` arg starting with '-' as an unknown option, so a rich-content message like '- Fixed the bug' makes notify-send exit non-zero and the toast silently never fires.",
+      "why_it_matters": "Claude Code rich content puts the assistant's own text into the body; a dash-leading line is plausible and would silently drop the notification.",
+      "confidence": "high",
+      "status": "fixed",
+      "resolution": "Extracted exported buildNotifySendArgs(notification, iconPath): ['--urgency', level, ...(icon?['--icon',icon]:[]), '--', title, message] — all options first, then `--`, then positionals. URGENCY_MAP/priority behavior unchanged.",
+      "verification": "tests/platforms.test.mjs asserts arg order and that a leading-dash message lands after `--`."
+    },
+    {
+      "id": "RT-17",
+      "title": "sendNtfy `new URL()` unguarded — violates the module's resolve-false/never-throw contract",
+      "severity": "medium",
+      "area": "error-visibility",
+      "evidence": "src/ntfy.mjs:31 — `const parsed = new URL(url)` was unguarded, unlike webhook.mjs:63-70 and sentry.mjs:75. A server typo with no scheme ('ntfy.sh') throws 'Invalid URL', crashing `aan test ntfy` with a raw stack instead of a clean false.",
+      "why_it_matters": "The channel modules promise never to throw so a bad config can't take down the hook or the CLI; ntfy was the one that could.",
+      "confidence": "high",
+      "status": "fixed",
+      "resolution": "Wrapped `new URL(url)` in try/catch → logHookError + resolve(false) naming the bad server (not the topic). Also wrapped transport.request setup in try/catch to mirror webhook.mjs's guard against synchronous throws on non-http(s) protocols/invalid headers.",
+      "verification": "tests/ntfy-send.test.mjs: a scheme-less server yields false with no throw."
+    },
+    {
+      "id": "MD-16",
+      "title": "README standalone install one-liners point at nonexistent files",
+      "severity": "high",
+      "area": "install-honesty",
+      "evidence": "README.md:134 (setup/install.ps1) and :139 (setup/install.sh) were advertised as curl|iex bootstrappers, but setup/ contained only patch-config.mjs — both URLs 404'd.",
+      "why_it_matters": "A trust-sensitive install path people are told to pipe into a shell must exist and work; a 404 (or worse, a silent no-op) is a broken first impression.",
+      "confidence": "high",
+      "status": "fixed",
+      "resolution": "Created setup/install.sh (set -euo pipefail, fails loudly) and setup/install.ps1 ($ErrorActionPreference='Stop'): both verify Node>=18 + npm with an actionable per-OS hint, then exec `npx --yes ai-agent-notifier@latest setup` forwarding args. setup/ is already in package.json files[].",
+      "verification": "Files created and readable; scripts are thin/no-network until the npx handoff. Piped-shell end-to-end run is a maintainer step after publish."
+    },
+    {
+      "id": "MD-17",
+      "title": "README claims a macOS terminal-notifier fallback that does not exist in code",
+      "severity": "medium",
+      "area": "test-honesty",
+      "evidence": "README.md:307 — 'Falls back to terminal-notifier for richer features if available'. grep for terminal-notifier across src/ and cli/ returns nothing; macOS uses osascript only.",
+      "why_it_matters": "The repo's extreme-honesty culture requires README claims to match code exactly.",
+      "confidence": "high",
+      "status": "fixed",
+      "resolution": "Deleted the claim (did not implement terminal-notifier)."
+    },
+    {
+      "id": "MD-18",
+      "title": "WSL over-claim: real cross-boundary toast delivery is asserted but never proven",
+      "severity": "low",
+      "area": "test-honesty",
+      "evidence": "README.md:51 ('real Windows toast notifications from inside WSL') and :314-319. Only detection + interop invocation are tested (tests/platforms-wsl.test.mjs, fully deps-injected); no CI proves a toast reaches the Windows host.",
+      "why_it_matters": "Matches how the repo already scopes Codex exec vs the TUI approval loop — claims must stop at what CI proves.",
+      "confidence": "high",
+      "status": "fixed",
+      "resolution": "Softened the feature bullet and Platform Details WSL section to 'routed to Windows over PowerShell interop' and added an explicit proof-boundary note in both the WSL section and the Testing footnotes explaining WSL has no table row on purpose."
+    },
+    {
+      "id": "CL-19",
+      "title": "doctor --deep silently no-ops on linux/win32",
+      "severity": "low",
+      "area": "cli-candor",
+      "evidence": "cli/doctor-checks.mjs — the `deep` flag is only consumed by the darwin toastAuthCheck; on other platforms it was accepted and ignored with no output.",
+      "why_it_matters": "A flag that silently does nothing misleads the user into thinking a deep verification ran.",
+      "confidence": "high",
+      "status": "fixed",
+      "resolution": "runChecks now pushes an explicit info-status row 'deep verification not available on <platform> (static checks only)' when --deep is passed on a platform with no deep probe; doctor.mjs ICON map gained an 'info' glyph; --json stays machine-parseable (new id 'deep-probe').",
+      "verification": "tests/doctor.test.mjs asserts the deep-probe info row on non-darwin."
+    },
+    {
+      "id": "CL-20",
+      "title": "`aan test <unknown-channel>` prints the header and exits 0 doing nothing",
+      "severity": "low",
+      "area": "cli-correctness",
+      "evidence": "cli/test.mjs — an unrecognised channel matched none of the do* gates, so the command printed the header and exited 0, reading as a silent success.",
+      "why_it_matters": "A typo'd channel should fail loudly, not look like it worked.",
+      "confidence": "high",
+      "status": "fixed",
+      "resolution": "Added exported KNOWN_CHANNELS = [toast, ntfy, webhook, bell, both]; an unknown channel prints 'Unknown channel: X (valid: ...)' to stderr and exits 1. NOTE: the task-suggested valid set listed 'all', but the code + README:147 use 'both' (no-arg = every channel); recorded the honest set that matches the code.",
+      "verification": "tests/cli-test.test.mjs asserts exit 1 + message; KNOWN_CHANNELS matches the documented set."
+    },
+    {
+      "id": "RT-18",
+      "title": "Hook stdout.write followed by immediate process.exit can drop the response",
+      "severity": "low",
+      "area": "runtime-correctness",
+      "evidence": "src/notify.mjs:201-202 — process.stdout.write(responseBody); process.exit(0). On a back-pressured stdout the buffered write can be lost before exit (notably the claude terminalSequence bell payload).",
+      "confidence": "medium",
+      "status": "fixed",
+      "resolution": "process.stdout.write(responseBody, () => process.exit(0)) — exit only after the write drains."
+    },
+    {
+      "id": "RT-19",
+      "title": "config `sources` block had no schema check — label/icon unvalidated",
+      "severity": "medium",
+      "area": "config-schema",
+      "evidence": "src/config-loader.mjs — 'sources' was in knownTop but had no checkBlock; a newline in sources.<tool>.label flows to notification.title and later corrupts the ntfy Title HTTP header at send time.",
+      "why_it_matters": "A control char in label/icon is a header-injection / send-failure vector; every other block is validated.",
+      "confidence": "high",
+      "status": "fixed",
+      "resolution": "Added a nested sources validator (like events): each sources.<tool> must be an object; label/icon must be strings with no control chars (charCodeAt < 0x20 or === 0x7f), wrong types deleted+reported so defaults win; unknown per-tool keys reported but kept.",
+      "verification": "tests/config-loader-validation.test.mjs: non-string label reverted, newline label rejected, unknown key kept, clean custom label passes."
+    },
+    {
+      "id": "RT-20",
+      "title": "macOS NC DB path interpolated into a sqlite file: URI without percent-encoding",
+      "severity": "low",
+      "area": "runtime-correctness",
+      "evidence": "src/platforms/macos-delivery.mjs:103,115 — `file:${dbPath}?mode=ro` / `file:${copy}?mode=ro`; a space in the home dir (/Users/Jane Doe/...) corrupts the URI.",
+      "confidence": "medium",
+      "status": "fixed",
+      "resolution": "Wrapped both interpolations in encodeURI() (keeps the `/` separators, encodes spaces)."
+    },
+    {
+      "id": "CL-21",
+      "title": "update-check compares versions with string `!==`, not a semver newer-than",
+      "severity": "medium",
+      "area": "cli-correctness",
+      "evidence": "cli/update-check.mjs:63 — `latest !== pkg.version`. With npm latest at 1.0.6 and the repo at 1.2.1, this reports 1.0.6 as an available 'update', nagging users to downgrade.",
+      "why_it_matters": "Directly wrong right now given the npm/repo version gap this pass also addresses.",
+      "confidence": "high",
+      "status": "fixed",
+      "resolution": "Added exported isNewer(a,b): field-by-field numeric semver compare (1.10.0 > 1.9.0), pre-release/build ignored, unparseable treated as not-newer; fetchLatest now resolves only when strictly newer. ~11 lines.",
+      "verification": "tests/update-check.test.mjs: strictly-newer true, equal/older false (1.0.6 vs 1.2.1), garbage false."
+    },
+    {
+      "id": "TC-23",
+      "title": "CI lanes run twice on same-repo PR branches (bare push + pull_request)",
+      "severity": "low",
+      "area": "ci-cost",
+      "evidence": "unit.yml, e2e.yml, agents.yml, toast-linux.yml, toast-macos.yml, toast-native.yml triggered on bare `push:` + `pull_request:`; concurrency keyed on github.ref does not dedupe push vs PR refs, so a same-repo PR branch ran every lane twice. agents.yml also ran the full 3-OS install matrix on docs-only commits.",
+      "confidence": "high",
+      "status": "fixed",
+      "resolution": "Restricted `push:` to `branches: [main]` on all six (mirroring the live-* lanes); pull_request unchanged. Added the shared paths-ignore ['**/*.md','docs/**','LICENSE','.gitignore'] to agents.yml on both push and pull_request.",
+      "verification": "YAML reviewed against the live-*.yml pattern already in the repo."
+    },
+    {
+      "id": "TC-24",
+      "title": "No npm release pipeline; npm latest (1.0.6) far behind the repo (1.2.0); zero tags/releases",
+      "severity": "high",
+      "area": "release-rails",
+      "evidence": "package.json version was 1.2.0 vs npm 1.0.6; no .github/workflows/release.yml; no git tags or GitHub releases.",
+      "why_it_matters": "Users installing from npm get a stale build; there was no automated, provenance-signed path to publish.",
+      "confidence": "high",
+      "status": "fixed",
+      "resolution": "Added .github/workflows/release.yml (triggers on push of tag v*): (a) 3-OS x node 18/20/22 unit matrix — npm test also covers the unit-safe toast tests (live paths gated behind AAN_TOAST_LIVE, unset); (b) tag/version match + plugin-manifest lockstep + `npm pack --dry-run`; (c) `npm publish --provenance --access public` with id-token: write + NPM_TOKEN; (d) `gh release create --verify-tag --generate-notes` with contents: write. Bumped to 1.2.1 via `npm version 1.2.1 --no-git-tag-version` (ran the repo's sync-plugin-version.mjs, syncing plugin.json + marketplace.json). No tag created, nothing published — the maintainer cuts the tag after adding NPM_TOKEN.",
+      "verification": "Version sync confirmed (package.json/plugin.json/marketplace.json all 1.2.1); release.yml is deliberately un-triggered until a v* tag is pushed."
+    },
+    {
+      "id": "MD-19",
+      "title": "docs/audits/ convention lapsed — demand passes 3-5 shipped with no audit record",
+      "severity": "low",
+      "area": "process",
+      "evidence": "docs/audits/ held only 2026-07-09-second-pass.json + schema.json; PRs #5-#8 (1.1.0 five-feature pass, macOS/Windows/Linux proof passes) landed without records.",
+      "confidence": "high",
+      "status": "fixed",
+      "resolution": "Wrote this record (docs/audits/2026-07-16-final-pass.json) against the existing schema, capturing all findings from both audit lenses."
+    },
+    {
+      "id": "RT-21",
+      "title": "windows.mjs has no `--` parity for leading-dash content (parallel to RT-16)",
+      "severity": "low",
+      "area": "toast-delivery",
+      "evidence": "The Windows toast backend passes title/message as PowerShell -File parameters. Reviewed for the same dash-parsing risk as Linux.",
+      "why_it_matters": "Considered because RT-16 was a real dash bug on Linux.",
+      "confidence": "medium",
+      "status": "wont_fix",
+      "resolution": "Accepted. A PowerShell [string] parameter consumes the next token positionally regardless of a leading dash; it only misparses if the message value exactly equals another declared parameter name — not the case for notification bodies. No `--` equivalent needed. Left unchanged."
+    },
+    {
+      "id": "CL-22",
+      "title": "patch-config TOML edits via string surgery (existing TODO CL-18)",
+      "severity": "low",
+      "area": "config-patching",
+      "evidence": "setup/patch-config.mjs performs Codex TOML edits with guarded string manipulation rather than a TOML parser (prior-pass finding CL-18).",
+      "confidence": "medium",
+      "status": "wont_fix",
+      "resolution": "Accepted, re-reviewed. The surgery is guarded and covered by patch-config*.test.mjs; introducing a TOML dependency contradicts the zero-dependency posture. Left as the documented CL-18 TODO."
+    },
+    {
+      "id": "RT-22",
+      "title": "rebuildHooksState / stripHooksStateKeys duplication",
+      "severity": "low",
+      "area": "maintainability",
+      "evidence": "The two helpers share structure but are intentionally separate to keep the corruption-preventing rebuild path isolated.",
+      "confidence": "medium",
+      "status": "wont_fix",
+      "resolution": "Accepted. Unifying them risks reintroducing the exact hooks-state corruption the split prevents; the duplication is deliberate and low-cost. Left unchanged."
+    },
+    {
+      "id": "TC-25",
+      "title": "No CI lane proves real WSL toast delivery to the Windows host",
+      "severity": "low",
+      "area": "test-coverage",
+      "evidence": "tests/platforms-wsl.test.mjs covers detection + interop invocation only; end-to-end cross-boundary delivery is unproven.",
+      "confidence": "high",
+      "status": "deferred",
+      "resolution": "Deferred — not feasible on hosted runners (a runner cannot host both a WSL guest and an interactive Windows desktop). Documented as a README proof boundary (MD-18) instead. Revisit only with a self-hosted WSL+desktop runner."
+    },
+    {
+      "id": "TC-26",
+      "title": "npm publish of v1.2.1 to the real user funnel",
+      "severity": "high",
+      "area": "release-rails",
+      "evidence": "npm latest is 1.0.6; release.yml exists but is un-triggered; NPM_TOKEN secret and a v1.2.1 tag are prerequisites.",
+      "confidence": "high",
+      "status": "deferred",
+      "resolution": "Blocked on maintainer: add the NPM_TOKEN repo secret (npm automation token, publish scope), then `git tag v1.2.1 && git push origin v1.2.1` to trigger release.yml. CI must not tag or publish itself."
+    },
+    {
+      "id": "TC-27",
+      "title": "Linux doctor --deep has no daemon read-back probe",
+      "severity": "low",
+      "area": "cli-candor",
+      "evidence": "cli/doctor-checks.mjs — --deep only has a real probe on darwin (NC DB read-back). Linux/win32 now report 'not available' (CL-19) rather than silently no-op.",
+      "confidence": "high",
+      "status": "deferred",
+      "resolution": "Deferred follow-up: build a Linux notification-daemon (e.g. dunst history) read-back so --deep can verify real delivery there, mirroring the macOS lane. This pass ships the honest 'not available' line as the interim behavior."
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-agent-notifier",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Desktop & phone notifications for AI coding agents in VS Code and CLI. Supports Claude Code, Codex, Gemini CLI, and Cursor with toast alerts and ntfy push notifications.",
   "type": "module",
   "bin": {

--- a/setup/install.ps1
+++ b/setup/install.ps1
@@ -1,0 +1,31 @@
+# setup/install.ps1 — standalone bootstrapper for ai-agent-notifier on Windows.
+# Intended to be piped:  irm .../setup/install.ps1 | iex
+# It verifies Node >= 18 and npm are present, then hands off to the real setup
+# wizard via `npx ai-agent-notifier@latest setup`, forwarding any extra args.
+#
+# $ErrorActionPreference = 'Stop' is deliberate: a bootstrapper people pipe into a
+# shell must fail LOUDLY and stop — never silently no-op — if a prerequisite is missing.
+$ErrorActionPreference = 'Stop'
+
+function Fail($msg) {
+  Write-Host "`nai-agent-notifier install failed: $msg" -ForegroundColor Red
+  exit 1
+}
+
+if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+  Fail "Node.js 18+ is required but 'node' was not found. Install it from https://nodejs.org (or: winget install OpenJS.NodeJS.LTS), then re-run this installer."
+}
+
+$nodeMajor = 0
+try { $nodeMajor = [int](node -p 'process.versions.node.split(".")[0]') } catch { $nodeMajor = 0 }
+if ($nodeMajor -lt 18) {
+  Fail "Node.js 18+ is required (found $(node -v)). Upgrade Node, then re-run this installer."
+}
+
+if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+  Fail "npm is required but was not found (it ships with Node.js). Reinstall Node 18+ from https://nodejs.org"
+}
+
+Write-Host "Node $(node -v) and npm $(npm -v) detected - launching ai-agent-notifier setup..."
+& npx --yes ai-agent-notifier@latest setup @args
+exit $LASTEXITCODE

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# setup/install.sh — standalone bootstrapper for ai-agent-notifier (no git clone).
+# Intended to be piped:  curl -fsSL .../setup/install.sh | bash
+# It verifies Node >= 18 and npm are present, then hands off to the real setup
+# wizard via `npx ai-agent-notifier@latest setup`, forwarding any extra args.
+#
+# `set -euo pipefail` is deliberate: a bootstrapper people pipe into a shell must
+# fail LOUDLY and stop — never silently no-op — if a prerequisite is missing.
+set -euo pipefail
+
+err() {
+  printf '\n\033[31mai-agent-notifier install failed:\033[0m %s\n' "$1" >&2
+  exit 1
+}
+
+if ! command -v node >/dev/null 2>&1; then
+  err "Node.js 18+ is required but 'node' was not found.
+  macOS:  brew install node
+  Linux:  install via your package manager, or see https://nodejs.org
+Then re-run this installer."
+fi
+
+NODE_MAJOR="$(node -p 'process.versions.node.split(".")[0]' 2>/dev/null || echo 0)"
+if [ "$NODE_MAJOR" -lt 18 ]; then
+  err "Node.js 18+ is required (found $(node -v)). Upgrade Node, then re-run this installer."
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+  err "npm is required but was not found (it ships with Node.js). Reinstall Node 18+ from https://nodejs.org"
+fi
+
+echo "Node $(node -v) and npm $(npm -v) detected — launching ai-agent-notifier setup..."
+exec npx --yes ai-agent-notifier@latest setup "$@"

--- a/src/config-loader.mjs
+++ b/src/config-loader.mjs
@@ -120,6 +120,39 @@ function validateUserConfig(user) {
     }
   }
 
+  // `sources` overrides the per-tool label/icon shown on notifications. It nests
+  // one level (sources.<tool>.{label,icon}) like `events`, so it needs its own
+  // pass rather than a flat checkBlock. A control char in a label — especially a
+  // newline — would corrupt the ntfy Title/Icon HTTP headers at send time, so a
+  // label/icon that isn't a single clean line is rejected (defaults win).
+  if (user.sources !== undefined) {
+    if (typeof user.sources !== 'object' || user.sources === null || Array.isArray(user.sources)) {
+      issues.push('"sources" must be an object');
+      delete user.sources;
+    } else {
+      for (const [tool, spec] of Object.entries(user.sources)) {
+        if (typeof spec !== 'object' || spec === null || Array.isArray(spec)) {
+          issues.push(`"sources.${tool}" must be an object`);
+          delete user.sources[tool];
+          continue;
+        }
+        for (const [key, val] of Object.entries(spec)) {
+          if (key !== 'label' && key !== 'icon') {
+            issues.push(`unknown key "sources.${tool}.${key}"`);
+            continue;
+          }
+          if (typeof val !== 'string') {
+            issues.push(`"sources.${tool}.${key}" must be a string, got ${typeof val}`);
+            delete spec[key];
+          } else if ([...val].some((ch) => ch.charCodeAt(0) < 0x20 || ch.charCodeAt(0) === 0x7f)) {
+            issues.push(`"sources.${tool}.${key}" must be a single-line string (no control characters)`);
+            delete spec[key];
+          }
+        }
+      }
+    }
+  }
+
   const knownTop = ['ntfy', 'toast', 'terminalBell', 'webhook', 'sentry', 'events', 'sources'];
   for (const key of Object.keys(user)) {
     if (!knownTop.includes(key)) issues.push(`unknown key "${key}"`);

--- a/src/notify.mjs
+++ b/src/notify.mjs
@@ -198,8 +198,9 @@ async function main() {
   // Write the hook response — normally '{}\n' (some tools, e.g. Cursor, expect
   // stdout output and may retry if they get nothing); on the successful claude
   // bell path it carries the terminalSequence set above.
-  process.stdout.write(responseBody);
-  process.exit(0);
+  // Exit only after the write drains: on a back-pressured stdout an immediate
+  // process.exit() can drop the hook response (e.g. the claude bell sequence).
+  process.stdout.write(responseBody, () => process.exit(0));
 }
 
 // Only run main when invoked directly as a hook (node src/notify.mjs ...),

--- a/src/ntfy.mjs
+++ b/src/ntfy.mjs
@@ -28,30 +28,49 @@ export function sendNtfy(ntfyConfig, notification) {
     }
 
     const { url, headers, body } = buildNtfyRequest(ntfyConfig, notification);
-    const parsed = new URL(url);
+
+    // A bare-hostname typo (server: "ntfy.sh" with no scheme) makes `new URL`
+    // throw, which would break this module's resolve-false-never-throw contract
+    // and crash `aan test ntfy` with a raw "Invalid URL" (mirrors webhook.mjs).
+    let parsed;
+    try {
+      parsed = new URL(url);
+    } catch {
+      logHookError('ntfy', new Error(`ntfy server is not a valid URL: ${ntfyConfig.server || 'https://ntfy.sh'}`));
+      resolve(false);
+      return;
+    }
     const transport = parsed.protocol === 'https:' ? https : http;
 
-    const req = transport.request(parsed, {
-      method: 'POST',
-      agent: false, // no keep-alive socket may outlive the hook's process.exit() (see sentry.mjs)
-      headers: { ...headers, 'Content-Type': 'text/plain; charset=utf-8' },
-      timeout: 5000,
-    }, (res) => {
-      res.resume(); // drain
-      const ok = res.statusCode >= 200 && res.statusCode < 300;
-      if (!ok) logHookError('ntfy', new Error(`ntfy server responded ${res.statusCode}`), { url: parsed.origin });
-      resolve(ok);
-    });
+    // transport.request can throw SYNCHRONOUSLY (not via 'error') on a non-http(s)
+    // protocol that still parses (e.g. ftp://) or invalid header chars — guard the
+    // whole setup so a bad config can never reject this promise (see webhook.mjs).
+    try {
+      const req = transport.request(parsed, {
+        method: 'POST',
+        agent: false, // no keep-alive socket may outlive the hook's process.exit() (see sentry.mjs)
+        headers: { ...headers, 'Content-Type': 'text/plain; charset=utf-8' },
+        timeout: 5000,
+      }, (res) => {
+        res.resume(); // drain
+        const ok = res.statusCode >= 200 && res.statusCode < 300;
+        if (!ok) logHookError('ntfy', new Error(`ntfy server responded ${res.statusCode}`), { url: parsed.origin });
+        resolve(ok);
+      });
 
-    req.on('error', (err) => {
+      req.on('error', (err) => {
+        logHookError('ntfy', err, { url: parsed.origin });
+        resolve(false);
+      });
+      req.on('timeout', () => {
+        req.destroy();
+        logHookError('ntfy', new Error('ntfy request timed out after 5000ms'), { url: parsed.origin });
+        resolve(false);
+      });
+      req.end(body);
+    } catch (err) {
       logHookError('ntfy', err, { url: parsed.origin });
       resolve(false);
-    });
-    req.on('timeout', () => {
-      req.destroy();
-      logHookError('ntfy', new Error('ntfy request timed out after 5000ms'), { url: parsed.origin });
-      resolve(false);
-    });
-    req.end(body);
+    }
   });
 }

--- a/src/platforms/linux.mjs
+++ b/src/platforms/linux.mjs
@@ -16,6 +16,21 @@ export const URGENCY_MAP = {
   min: 'low',
 };
 
+// notify-send parses positionals with GLib GOption: any argument before the
+// `--` end-of-options guard that begins with `-` is taken as an (unknown) option
+// and the call fails. The message body is agent-controlled — rich content can
+// start with a dash ("- Fixed the bug") — so options MUST come first, then `--`,
+// then title/message, or a dash-leading toast silently never fires.
+export function buildNotifySendArgs(notification, iconPath) {
+  return [
+    '--urgency', URGENCY_MAP[notification.priority] || 'low',
+    ...(iconPath ? ['--icon', iconPath] : []),
+    '--',
+    notification.title,
+    notification.message,
+  ];
+}
+
 export function sendToast(notification) {
   return new Promise((resolve) => {
     // Per-source icon: assets/icons/<source>.png, fallback to legacy icon.png
@@ -24,15 +39,7 @@ export function sendToast(notification) {
     if (!iconPath || !fs.existsSync(iconPath)) {
       iconPath = path.join(getConfigDir(), 'icon.png');
     }
-    const args = [
-      notification.title,
-      notification.message,
-      '--urgency', URGENCY_MAP[notification.priority] || 'low',
-    ];
-
-    if (fs.existsSync(iconPath)) {
-      args.push('--icon', iconPath);
-    }
+    const args = buildNotifySendArgs(notification, fs.existsSync(iconPath) ? iconPath : '');
 
     execFile('notify-send', args, { timeout: 5000 }, (err, stdout, stderr) => {
       if (err) logHookError('toast:linux', err, { stderr: (stderr || '').slice(0, 400) });

--- a/src/platforms/macos-delivery.mjs
+++ b/src/platforms/macos-delivery.mjs
@@ -100,7 +100,9 @@ function queryRecordHex(dbPath, limit = 20) {
   const sql = `select hex(data) from record order by rowid desc limit ${limit};`;
   const rowsOf = (out) => out.split('\n').map((l) => l.trim()).filter(Boolean);
   try {
-    const out = execFileSync('sqlite3', [`file:${dbPath}?mode=ro`, sql], { encoding: 'utf8' });
+    // Percent-encode the path (encodeURI keeps the `/` separators) so a space in
+    // the home dir — /Users/Jane Doe/… — doesn't corrupt the sqlite file: URI.
+    const out = execFileSync('sqlite3', [`file:${encodeURI(dbPath)}?mode=ro`, sql], { encoding: 'utf8' });
     return { rows: rowsOf(out), error: null };
   } catch (liveErr) {
     // Fallback: snapshot the db and its WAL sidecars to a temp dir and read the
@@ -112,7 +114,7 @@ function queryRecordHex(dbPath, limit = 20) {
       for (const suffix of ['', '-wal', '-shm']) {
         if (fs.existsSync(dbPath + suffix)) fs.copyFileSync(dbPath + suffix, copy + suffix);
       }
-      const out = execFileSync('sqlite3', [`file:${copy}?mode=ro`, sql], { encoding: 'utf8' });
+      const out = execFileSync('sqlite3', [`file:${encodeURI(copy)}?mode=ro`, sql], { encoding: 'utf8' });
       return { rows: rowsOf(out), error: null };
     } catch (copyErr) {
       const msg = [liveErr, copyErr].map((e) => String((e && (e.stderr || e.message)) || '')).join(' ');

--- a/tests/cli-test.test.mjs
+++ b/tests/cli-test.test.mjs
@@ -1,0 +1,28 @@
+// tests/cli-test.test.mjs — `aan test <channel>` argument validation.
+// The unknown-channel path must fail loudly (exit 1) instead of printing the
+// header and exiting 0, which reads as a silent success.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { run, KNOWN_CHANNELS } from '../cli/test.mjs';
+
+test('an unknown channel exits 1 and names the offending value + the valid set', async () => {
+  const origErr = console.error;
+  const origExit = process.exitCode;
+  let msg = '';
+  console.error = (s) => { msg += String(s); };
+  try {
+    process.exitCode = 0;
+    await run('slack'); // validated before any config/network work, so this is hermetic
+    assert.equal(process.exitCode, 1);
+    assert.match(msg, /Unknown channel/);
+    assert.match(msg, /slack/);
+    assert.match(msg, /toast/); // lists the valid channels
+  } finally {
+    console.error = origErr;
+    process.exitCode = origExit;
+  }
+});
+
+test('KNOWN_CHANNELS is exactly the documented set', () => {
+  assert.deepEqual(KNOWN_CHANNELS, ['toast', 'ntfy', 'webhook', 'bell', 'both']);
+});

--- a/tests/config-loader-validation.test.mjs
+++ b/tests/config-loader-validation.test.mjs
@@ -116,6 +116,46 @@ describe('loadConfigResult', () => {
     assert.equal(config.webhook.format, 'telegram', 'format kept so the send-time hint fires');
   });
 
+  it('sources: a wrong-typed label is reported AND dropped so the default label wins', () => {
+    fs.writeFileSync(configPath, JSON.stringify({
+      sources: { claude: { label: 42, icon: 'https://x/i.png' } },
+    }), 'utf8');
+    const { config, problem } = loadConfigResult(configPath);
+    assert.equal(problem.type, 'validate');
+    assert.match(problem.message, /"sources\.claude\.label" must be a string, got number/);
+    assert.equal(config.sources.claude.label, 'Claude Code', 'default label kept');
+    assert.equal(config.sources.claude.icon, 'https://x/i.png', 'good sibling value kept');
+  });
+
+  it('sources: a label with a control char (newline) is rejected — it would corrupt the ntfy Title header', () => {
+    fs.writeFileSync(configPath, JSON.stringify({
+      sources: { codex: { label: 'Codex\nInjected: header' } },
+    }), 'utf8');
+    const { config, problem } = loadConfigResult(configPath);
+    assert.equal(problem.type, 'validate');
+    assert.match(problem.message, /"sources\.codex\.label" must be a single-line string/);
+    assert.equal(config.sources.codex.label, 'Codex', 'default label kept after rejecting the poisoned one');
+  });
+
+  it('sources: an unknown per-tool key is reported but kept', () => {
+    fs.writeFileSync(configPath, JSON.stringify({
+      sources: { claude: { label: 'Claude', color: 'purple' } },
+    }), 'utf8');
+    const { config, problem } = loadConfigResult(configPath);
+    assert.equal(problem.type, 'validate');
+    assert.match(problem.message, /unknown key "sources\.claude\.color"/);
+    assert.equal(config.sources.claude.color, 'purple', 'unknown key kept');
+  });
+
+  it('sources: a clean custom label/icon produces no problem', () => {
+    fs.writeFileSync(configPath, JSON.stringify({
+      sources: { claude: { label: 'My Claude', icon: 'https://x/i.png' } },
+    }), 'utf8');
+    const { config, problem } = loadConfigResult(configPath);
+    assert.equal(problem, null);
+    assert.equal(config.sources.claude.label, 'My Claude');
+  });
+
   it('a fully valid user config produces no problem', () => {
     fs.writeFileSync(configPath, JSON.stringify({
       ntfy: { enabled: true, topic: 'aan-test' },

--- a/tests/doctor.test.mjs
+++ b/tests/doctor.test.mjs
@@ -37,6 +37,15 @@ test('runChecks never throws even with a hostile config', async () => {
   await assert.doesNotReject(runChecks({ config: { events: 'not-an-object' }, deep: false }));
 });
 
+test('deep on a platform with no deep probe reports it explicitly (never silently no-ops)', async (t) => {
+  if (os.platform() === 'darwin') return t.skip('darwin has a real --deep probe (NC read-back)');
+  const results = await runChecks({ config: baseConfig(), deep: true });
+  const probe = results.find((r) => r.id === 'deep-probe');
+  assert.ok(probe, 'a deep-probe row must be present when --deep is unavailable');
+  assert.equal(probe.status, 'info');
+  assert.match(probe.detail, /deep verification not available/);
+});
+
 function baseConfig() {
   return {
     toast: { enabled: true }, ntfy: { enabled: false, topic: '' },

--- a/tests/ntfy-send.test.mjs
+++ b/tests/ntfy-send.test.mjs
@@ -77,4 +77,11 @@ describe('sendNtfy (real local HTTP server, no mocking)', () => {
     const ok = await sendNtfy({ server: 'http://127.0.0.1:1', topic: 't' }, { title: 'T', message: 'm' });
     assert.equal(ok, false);
   });
+
+  it('returns false (never throws) when the server is a bare hostname with no scheme', async () => {
+    // A "ntfy.sh" typo (no https://) makes `new URL` throw; the resolve-false
+    // contract must hold so `aan test ntfy` reports cleanly instead of crashing.
+    const ok = await sendNtfy({ server: 'ntfy.sh', topic: 't' }, { title: 'T', message: 'm' });
+    assert.equal(ok, false);
+  });
 });

--- a/tests/platforms.test.mjs
+++ b/tests/platforms.test.mjs
@@ -8,7 +8,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import os from 'node:os';
 import { esc } from '../src/platforms/macos.mjs';
-import { URGENCY_MAP } from '../src/platforms/linux.mjs';
+import { URGENCY_MAP, buildNotifySendArgs } from '../src/platforms/linux.mjs';
 
 const platform = os.platform();
 
@@ -39,6 +39,28 @@ describe('linux URGENCY_MAP — ntfy priority → notify-send urgency', () => {
     assert.equal(URGENCY_MAP.high, 'normal');
     assert.equal(URGENCY_MAP.default, 'low');
     assert.equal(URGENCY_MAP.low, 'low');
+  });
+});
+
+describe('linux buildNotifySendArgs — options precede the `--` end-of-options guard', () => {
+  it('puts every option before `--` and title/message after it', () => {
+    const args = buildNotifySendArgs({ title: 'Claude Code', message: 'app: Task complete', priority: 'urgent' }, '/i.png');
+    assert.deepEqual(args, ['--urgency', 'critical', '--icon', '/i.png', '--', 'Claude Code', 'app: Task complete']);
+  });
+
+  it('keeps a leading-dash message AFTER `--` so notify-send never parses it as an option', () => {
+    // Rich content can start with a dash ("- Fixed the bug"); without the guard
+    // GOption would reject it as an unknown option and the toast would silently fail.
+    const args = buildNotifySendArgs({ title: 'T', message: '- Fixed the bug', priority: 'default' }, '');
+    const sep = args.indexOf('--');
+    assert.ok(sep !== -1, 'args must contain the `--` guard');
+    assert.equal(args[sep + 2], '- Fixed the bug');
+    assert.ok(args.indexOf('- Fixed the bug') > sep, 'the dash-leading message must come after `--`');
+  });
+
+  it('omits --icon entirely when no icon path is given', () => {
+    const args = buildNotifySendArgs({ title: 'T', message: 'm', priority: 'low' }, '');
+    assert.deepEqual(args, ['--urgency', 'low', '--', 'T', 'm']);
   });
 });
 

--- a/tests/update-check.test.mjs
+++ b/tests/update-check.test.mjs
@@ -5,7 +5,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { resolveUpdate, UPDATE_TTL_MS } from '../cli/update-check.mjs';
+import { resolveUpdate, UPDATE_TTL_MS, isNewer } from '../cli/update-check.mjs';
 
 const tmpDir = path.join(os.tmpdir(), 'update-check-test-' + Date.now());
 const cachePath = () => path.join(tmpDir, `.update-check-${Math.random().toString(36).slice(2)}.json`);
@@ -50,5 +50,21 @@ describe('resolveUpdate caching', () => {
     const cached = JSON.parse(fs.readFileSync(cp, 'utf8'));
     assert.equal(cached.checkedAt, 5000);
     assert.equal(cached.latest, null);
+  });
+});
+
+describe('isNewer — semver "should we nag?" gate', () => {
+  it('true only when strictly newer, field-by-field numeric (1.10.0 > 1.9.0)', () => {
+    assert.equal(isNewer('1.10.0', '1.9.0'), true);
+    assert.equal(isNewer('2.0.0', '1.9.9'), true);
+    assert.equal(isNewer('1.2.2', '1.2.1'), true);
+  });
+  it('false when equal or OLDER — never nags a user to downgrade (repo 1.2.1 vs npm 1.0.6)', () => {
+    assert.equal(isNewer('1.2.1', '1.2.1'), false);
+    assert.equal(isNewer('1.0.6', '1.2.1'), false);
+    assert.equal(isNewer('1.9.0', '1.10.0'), false);
+  });
+  it('unparseable input is treated as not-newer (stays quiet)', () => {
+    assert.equal(isNewer('garbage', '1.2.1'), false);
   });
 });


### PR DESCRIPTION
Two-lens audit remediation. One branch, one PR. Nothing tagged or published.

## Bugs (regression-tested)
- **Linux notify-send `--` guard** (`src/platforms/linux.mjs`): options now precede a `--` end-of-options guard, so a dash-leading rich-content body (e.g. `- Fixed the bug`) no longer silently drops the toast via GLib GOption.
- **ntfy `new URL()` guard** (`src/ntfy.mjs`): a scheme-less server typo (`ntfy.sh`) now resolves false instead of throwing, honoring the never-throw contract (mirrors `webhook.mjs`).

## Honest user-facing surface
- **Real install bootstrappers**: created `setup/install.sh` (`set -euo pipefail`) and `setup/install.ps1` (`$ErrorActionPreference='Stop'`) — the advertised README one-liners pointed at files that didn't exist. Both check Node≥18 + npm with an actionable per-OS hint, then hand off to `npx ai-agent-notifier@latest setup`.
- Deleted the nonexistent macOS `terminal-notifier` fallback claim.
- Softened WSL wording to what CI proves + added an explicit proof boundary.
- `doctor --deep` now reports "not available" on linux/win32 instead of silently no-opping (`--json` stays parseable).

## Small correctness fixes
- `aan test <unknown-channel>` exits 1 with the valid set (was header + exit 0).
- `update-check` uses a semver newer-than (`isNewer`), not string `!==` — which currently nags users to "update" from repo 1.2.1 down to npm's 1.0.6.
- `notify.mjs` exits only after stdout drains (back-pressure could drop the reply).
- `config-loader` validates the `sources` block: rejects control chars in label/icon that would corrupt the ntfy Title header.
- Percent-encode the macOS NC DB path in the sqlite `file:` URI.

## CI + release rails
- Restricted `push` to `branches: [main]` on six lanes (unit, e2e, agents, toast-linux/macos/native) to stop same-repo PR double-runs; added `paths-ignore` to `agents.yml`.
- Added `.github/workflows/release.yml` (tag `v*` → 3-OS×node 18/20/22 unit matrix, tag/version + manifest lockstep + `npm pack --dry-run`, `npm publish --provenance`, `gh release create`). Bumped to **1.2.1** via the repo's version script (package.json + plugin.json + marketplace.json synced). **No tag created, nothing published.**

## Record
`docs/audits/2026-07-16-final-pass.json` — 20 findings across both lenses (fixed / wont_fix / deferred), schema-validated.

## Local verification
Full unit suite green on Windows: **308 tests, 300 pass, 8 platform-skipped, 0 fail**, including all new regression tests.

## Maintainer steps remaining
1. Add the **`NPM_TOKEN`** repo secret (npm automation token, publish scope).
2. `git tag v1.2.1 && git push origin v1.2.1` to trigger `release.yml` (publishes 1.2.1 + drafts the GitHub release).
3. Optionally add `release` / the deduped lanes to branch protection.