### PR TITLE
docs: CHANGELOG.md + curated release notes for the 1.2.1 launch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,13 @@ jobs:
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Create GitHub release with generated notes
-        run: gh release create "$GITHUB_REF_NAME" --verify-tag --generate-notes
+      - name: Extract curated release notes from CHANGELOG.md
+        # Fails loudly if this version has no CHANGELOG section, so we never
+        # publish a GitHub release with empty or wrong notes.
+        run: node scripts/extract-changelog.mjs "${GITHUB_REF_NAME#v}" > RELEASE_NOTES.md
+      - name: Create GitHub release
+        # Curated CHANGELOG section as the body; --generate-notes appends the
+        # auto-generated commit/PR list below it.
+        run: gh release create "$GITHUB_REF_NAME" --verify-tag --notes-file RELEASE_NOTES.md --generate-notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,94 @@
+# Changelog
+
+All notable changes to `ai-agent-notifier` are documented here. This project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
+
+## [1.2.1] — 2026-07-16
+
+**First release published to npm since 1.0.6.** Everything in 1.1.0 and 1.2.0
+below ships to npm users for the first time with this release.
+
+### Fixed
+- **Linux toasts silently dropped for messages starting with `-`.** `notify-send`
+  was invoked positionals-first with no `--` end-of-options guard, so rich
+  content beginning with a dash (e.g. an assistant line like `- Fixed the bug`)
+  was parsed as an unknown option and the toast never fired. Arguments are now
+  options, then `--`, then title/message.
+- **`aan test ntfy` crashed on a scheme-less server value.** An unguarded
+  `new URL()` broke the ntfy sender's resolve-false/never-throw contract; a typo
+  like `ntfy.sh` (no `https://`) now degrades cleanly instead of throwing.
+- **Update-check nagged a downgrade.** The version comparison used string
+  inequality, so a user on 1.2.x was told to "update" to the older npm `latest`.
+  It now uses a proper semver comparison.
+- **`npm test` never ran on Windows with Node 18/20.** Test globs are expanded
+  by the runner itself rather than relying on shell globbing.
+
+### Added
+- **Real install one-liners.** `setup/install.sh` and `setup/install.ps1` now
+  exist — the README `curl | bash` / `irm | iex` commands previously 404'd and
+  silently no-opped. Both preflight Node ≥ 18 + npm, fail loudly, and hand off
+  to `npx ai-agent-notifier@latest setup`.
+- **`aan doctor --deep` verifies delivery on Linux.** Fires the real toast with
+  a unique marker and reads it back out of `dunst`'s own history, degrading
+  honestly (dispatched-but-unverified) when no reader daemon is present. The
+  win32 backend check is now a real probe (PowerShell + BurntToast + execution
+  policy) instead of a hardcoded `ok`.
+- **Release pipeline.** Pushing a `v*` tag runs a 3-OS × Node 18/20/22 matrix,
+  verifies tag/`package.json`/plugin-manifest lockstep and the `npm pack`
+  payload, then publishes with `--provenance` and drafts a GitHub release. CI
+  never tags or publishes on its own — the maintainer cuts the tag.
+
+### Changed
+- **Honest documentation.** Removed a README claim of a macOS `terminal-notifier`
+  fallback that never existed in code; scoped the WSL claims to the
+  detection/interop behavior that is actually tested.
+- **CI de-duplicated.** Push and pull-request runs no longer double-fire; push
+  triggers are restricted to `main`.
+- **Hardened live-push assertions.** The live E2E lanes now always log the
+  received push and hard-assert the deterministic router body, closing an
+  observability gap.
+
+## [1.2.0] — 2026-07-16 — Real-delivery verification
+
+Notifications can fail **silently** — `osascript`/`notify-send`/BurntToast all
+exit `0` even when nothing renders. This line replaces "the command exited 0"
+with proof of the real user experience, so CI goes red when a real user would
+have seen nothing.
+
+### Added
+- **macOS:** a fired notification is read back out of Notification Center's own
+  SQLite database and matched to the exact payload (layer 2 — OS store recorded).
+- **Linux:** layer-3 render proof — the notification text is OCR-verified as
+  legible pixels on a real X display, not just recorded by the daemon.
+- **Windows:** layer-2 proof — the toast is read back out of `wpndatabase.db`
+  with the exact nonce in its title and body, promoting the lane from exit-0.
+
+## [1.1.0] — 2026-07-10
+
+Five features selected from a verified user-demand research pass, plus a second
+audit pass hardening observability and the CLI.
+
+### Added
+- **Terminal bell channel** via `terminalSequence` — the hook reply carries a
+  bell that Claude Code (≥ 2.1.141) rings through its own terminal write path,
+  fixing the silent `/dev/tty` failure after hooks lost their TTY.
+- **Codex approval alerts** — registers the `PermissionRequest` hook event so
+  Codex approval prompts raise a notification.
+- **Transcript-derived rich content** — toasts and webhooks can show the
+  assistant's actual question or last message (bounded, sanitized). ntfy stays
+  generic by default, since public ntfy.sh topics are guessable — rich content
+  there is opt-in.
+- **WSL toast delivery** — notifications from inside WSL surface on the Windows
+  host.
+- **Webhook channel** — deliver notifications to an arbitrary HTTP endpoint.
+
+### Changed
+- Every hook failure now lands in a bounded `errors.log` (surfaced by `status`,
+  optionally mirrored to Sentry via a zero-dependency client), config keys
+  renamed to what they mean with validation and migration hints, SHA-pinned CI
+  actions, and a ~50× smaller npm package.
+
+## [1.0.6] — 2026-06-19
+
+Previous release published to npm. Baseline for the changes above.

--- a/scripts/extract-changelog.mjs
+++ b/scripts/extract-changelog.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// Print the CHANGELOG.md section for a single version, for use as a GitHub
+// release body. Usage: node scripts/extract-changelog.mjs 1.2.1
+//
+// Finds the `## [<version>]` heading and prints every line under it up to (but
+// not including) the next `## [` heading. Exits non-zero if the version has no
+// section, so the release job fails loudly rather than publishing empty notes.
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+export function extractSection(markdown, version) {
+  const lines = markdown.split(/\r?\n/);
+  // Match `## [1.2.1]` — the bracketed version at the start of an h2 heading.
+  const isHeading = (line) => /^##\s+\[/.test(line);
+  const target = `## [${version}]`;
+  let start = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith(target)) {
+      start = i;
+      break;
+    }
+  }
+  if (start === -1) return null;
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (isHeading(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+  // Drop the heading line itself and trim surrounding blank lines.
+  return lines.slice(start + 1, end).join('\n').trim();
+}
+
+function main() {
+  const version = process.argv[2];
+  if (!version) {
+    console.error('usage: extract-changelog.mjs <version>');
+    process.exit(2);
+  }
+  const here = dirname(fileURLToPath(import.meta.url));
+  const changelogPath = join(here, '..', 'CHANGELOG.md');
+  const md = readFileSync(changelogPath, 'utf8');
+  const section = extractSection(md, version);
+  if (section === null || section.length === 0) {
+    console.error(`no CHANGELOG.md section found for version ${version}`);
+    process.exit(1);
+  }
+  process.stdout.write(section + '\n');
+}
+
+// Run only when invoked directly, not when imported by the test.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/tests/extract-changelog.test.mjs
+++ b/tests/extract-changelog.test.mjs
@@ -1,0 +1,60 @@
+// tests/extract-changelog.test.mjs — the release-notes extractor slices exactly
+// one version section out of CHANGELOG.md. Pure function, no I/O.
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { extractSection } from '../scripts/extract-changelog.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const changelog = fs.readFileSync(path.join(here, '..', 'CHANGELOG.md'), 'utf8');
+
+const SAMPLE = [
+  '# Changelog',
+  '',
+  '## [2.0.0] — 2026-08-01',
+  '',
+  '### Added',
+  '- second thing',
+  '',
+  '## [1.0.0] — 2026-01-01',
+  '',
+  '### Added',
+  '- first thing',
+  '',
+].join('\n');
+
+describe('extractSection', () => {
+  it('returns the body of the requested version, heading excluded', () => {
+    const out = extractSection(SAMPLE, '2.0.0');
+    assert.equal(out, '### Added\n- second thing');
+  });
+
+  it('stops at the next version heading (no bleed-through)', () => {
+    const out = extractSection(SAMPLE, '2.0.0');
+    assert.ok(!out.includes('first thing'), 'must not include the older section');
+  });
+
+  it('extracts the last section with no trailing heading', () => {
+    const out = extractSection(SAMPLE, '1.0.0');
+    assert.equal(out, '### Added\n- first thing');
+  });
+
+  it('returns null for a version with no section', () => {
+    assert.equal(extractSection(SAMPLE, '9.9.9'), null);
+  });
+
+  it('does not partial-match a version prefix', () => {
+    // Asking for 1.0 must not match the [1.0.0] heading.
+    assert.equal(extractSection(SAMPLE, '1.0'), null);
+  });
+
+  it('finds the current package version in the real CHANGELOG.md', () => {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(here, '..', 'package.json'), 'utf8'),
+    );
+    const out = extractSection(changelog, pkg.version);
+    assert.ok(out && out.length > 0, `CHANGELOG.md is missing a [${pkg.version}] section`);
+  });
+});


### PR DESCRIPTION
Prep for the first npm publish since 1.0.6. The release job used `--generate-notes` only, so a published 1.2.1 GitHub release would show a raw commit list rather than a readable changelog.

## What this adds
- **`CHANGELOG.md`** — Keep a Changelog format, every entry traceable to a merged PR:
  - **1.2.1** — 2 real bug fixes (notify-send leading-dash, ntfy URL guard) + update-check semver + Windows test globs; real install one-liners; `doctor --deep` Linux read-back; release pipeline; honesty edits.
  - **1.2.0** — real-delivery verification (macOS NC DB, Linux OCR layer-3, Windows wpndb layer-2).
  - **1.1.0** — five features (terminal bell, Codex approvals, rich content, WSL toasts, webhook).
  - **1.0.6** — baseline currently on npm.
- **`scripts/extract-changelog.mjs`** — prints one version's section for the release body; **exits non-zero** if the version has no section (a future release fails loudly instead of publishing empty notes).
- **`release.yml`** — release body is now the curated CHANGELOG section, with `--generate-notes` appended below for the full commit/PR list. (Verified `gh` accepts `--notes-file` + `--generate-notes` together.)
- **`tests/extract-changelog.test.mjs`** — 6 cases, including a guard that `CHANGELOG.md` always carries a section for the current `package.json` version.

## Verification
- Full suite: 318 tests, 310 pass, 8 platform-skip, 0 fail.
- `extract-changelog.mjs 1.2.1` prints the correct section; `9.9.9` exits 1.

No version bump, no tag, no publish — this only shapes what the eventual `v1.2.1` release will display.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>