### PR TITLE
ci: tokenless npm publishing via Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,16 @@ name: Release
 # CI never tags itself — the maintainer cuts the release:
 #   npm version <patch|minor|major>   # bumps package.json + syncs plugin manifests
 #   git push && git push --tags       # the tag push triggers THIS workflow
-# Requires the NPM_TOKEN repo secret (an npm automation token with publish rights).
+#
+# Auth is TOKENLESS via npm Trusted Publishing (OIDC) — there is NO long-lived
+# NPM_TOKEN secret to store, rotate, or leak. The maintainer configures a
+# Trusted Publisher once at npmjs.com → the ai-agent-notifier package → Settings
+# → Trusted Publisher → GitHub Actions, with:
+#   Organization/user: DevinoSolutions
+#   Repository:        ai-agent-notifier
+#   Workflow filename: release.yml
+# npm then trusts a short-lived OIDC token minted by THIS workflow (id-token:
+# write) and no other. Provenance attestations are generated automatically.
 on:
   push:
     tags: ['v*']
@@ -70,18 +79,22 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # create the GitHub release
-      id-token: write # npm provenance attestation (Sigstore / OIDC)
+      id-token: write # mint the OIDC token npm trusts for auth + provenance
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
+      - name: Ensure npm supports trusted publishing (OIDC needs >= 11.5.1)
+        # Node 22 bundles npm 10.x; trusted publishing requires npm >= 11.5.1.
+        run: npm install -g npm@latest
       - run: npm install
-      - name: Publish to npm with provenance
+      - name: Publish to npm (tokenless, OIDC trusted publishing)
+        # No NODE_AUTH_TOKEN: npm detects the GitHub Actions OIDC environment and
+        # authenticates against the configured Trusted Publisher. Provenance is
+        # emitted automatically; --provenance is kept as an explicit assertion.
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Extract curated release notes from CHANGELOG.md
         # Fails loudly if this version has no CHANGELOG section, so we never
         # publish a GitHub release with empty or wrong notes.

--- a/docs/audits/2026-07-16-final-pass.json
+++ b/docs/audits/2026-07-16-final-pass.json
@@ -16,7 +16,7 @@
     ],
     "checks_failed": [],
     "blocked": [
-      "npm publish of v1.2.1 — requires the maintainer to add the NPM_TOKEN repo secret and push a v1.2.1 tag; CI must never publish or tag itself (release.yml is the rail, deliberately un-triggered)",
+      "npm publish of v1.2.1 — requires the maintainer to configure an npm Trusted Publisher (OIDC) for DevinoSolutions/ai-agent-notifier + release.yml at npmjs.com, then push a v1.2.1 tag; auth is tokenless (no NPM_TOKEN secret) and CI must never publish or tag itself (release.yml is the rail, deliberately un-triggered). [Superseded the earlier NPM_TOKEN-secret plan.]",
       "Real WSL toast-to-Windows-host delivery — not provable on a hosted GitHub runner (cannot host a WSL guest and an interactive Windows desktop together); documented as a proof boundary instead",
       "Linux doctor --deep daemon read-back — CLOSED in the follow-up post-audit hardening pass (TC-27 now 'fixed': dunst-history read-back probe + CI gate on toast-linux.yml)"
     ]
@@ -227,10 +227,10 @@
       "title": "npm publish of v1.2.1 to the real user funnel",
       "severity": "high",
       "area": "release-rails",
-      "evidence": "npm latest is 1.0.6; release.yml exists but is un-triggered; NPM_TOKEN secret and a v1.2.1 tag are prerequisites.",
+      "evidence": "npm latest is 1.0.6; release.yml exists but is un-triggered; an npm Trusted Publisher (OIDC) config and a v1.2.1 tag are prerequisites.",
       "confidence": "high",
       "status": "deferred",
-      "resolution": "Blocked on maintainer: add the NPM_TOKEN repo secret (npm automation token, publish scope), then `git tag v1.2.1 && git push origin v1.2.1` to trigger release.yml. CI must not tag or publish itself."
+      "resolution": "Blocked on maintainer: configure an npm Trusted Publisher (OIDC) for DevinoSolutions/ai-agent-notifier + release.yml at npmjs.com (tokenless — no NPM_TOKEN secret; supersedes the earlier automation-token plan), then `git tag v1.2.1 && git push origin v1.2.1` to trigger release.yml. CI must not tag or publish itself."
     },
     {
       "id": "TC-27",


### PR DESCRIPTION
Answers "is there a more secure way than storing an NPM_TOKEN?" — yes: **npm Trusted Publishing** over GitHub Actions **OIDC** (GA 2025-07-31). No long-lived secret exists to leak; each publish uses a short-lived token cryptographically scoped to **this repo + this workflow**, and only `release.yml` can mint it. Provenance is emitted automatically.

## Workflow changes (`release.yml` publish job)
- `permissions: id-token: write` was already present (it was there for provenance) — it now also **authenticates** the publish.
- **Adds `npm install -g npm@latest`** — Node 22 bundles npm 10.x, but trusted publishing needs **npm ≥ 11.5.1**.
- **Removes `NODE_AUTH_TOKEN` / `secrets.NPM_TOKEN`** from `npm publish`. npm auto-detects the OIDC environment and authenticates against the configured Trusted Publisher.

## What the maintainer does instead (one-time, no secret)
On npmjs.com → the **ai-agent-notifier** package → **Settings → Trusted Publisher → GitHub Actions**:
- Organization/user: `DevinoSolutions`
- Repository: `ai-agent-notifier`
- Workflow filename: `release.yml`

(The package already exists on npm as 1.0.6, so this can be configured now — no chicken-and-egg. `package.json` `repository` already points at the matching repo.)

Then launch is just: `git tag v1.2.1 && git push origin v1.2.1`.

## Honesty note
The OIDC publish path only executes on a real `v*` tag push, so **no CI lane exercises it** (same as the token path it replaces). It's verified by construction: YAML parses, `id-token: write` present, zero `NODE_AUTH_TOKEN` step env, npm upgraded before publish. If the first publish ever fails auth, the cause is a Trusted Publisher field mismatch (repo/workflow name) — not code.

Audit record TC-26 updated from the NPM_TOKEN plan to the tokenless path.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>