### PR TITLE
rename: ai-agent-notifier → anotifier (package, CLI, config dir, repo, site)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "ai-agent-notifier",
+  "name": "anotifier",
   "owner": {
     "name": "DevinoSolutions",
     "url": "https://github.com/DevinoSolutions"
@@ -9,12 +9,12 @@
     "version": "1.2.1"
   },
   "plugins": [{
-    "name": "ai-agent-notifier",
+    "name": "anotifier",
     "source": "./",
     "description": "Desktop & phone notifications for AI coding agents. Supports Claude Code, Codex, Gemini CLI, and Cursor with toast alerts and ntfy push.",
     "version": "1.2.1",
     "author": { "name": "DevinoSolutions" },
-    "repository": "https://github.com/DevinoSolutions/ai-agent-notifier",
+    "repository": "https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor",
     "license": "AGPL-3.0-or-later",
     "keywords": ["notifications", "claude-code", "codex", "gemini-cli", "cursor", "vscode", "ai-agent", "ai-coding", "coding-agent", "toast", "ntfy", "push-notifications", "desktop-notifications", "hooks", "developer-tools", "cross-platform", "cli", "productivity"],
     "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
-  "name": "ai-agent-notifier",
+  "name": "anotifier",
   "version": "1.2.1",
   "description": "Desktop & phone notifications for AI coding agents in VS Code and CLI. Supports Claude Code, Codex, Gemini CLI, and Cursor.",
   "author": {
     "name": "DevinoSolutions",
     "url": "https://github.com/DevinoSolutions"
   },
-  "repository": "https://github.com/DevinoSolutions/ai-agent-notifier",
+  "repository": "https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor",
   "license": "AGPL-3.0-or-later",
   "keywords": ["notifications", "claude-code", "codex", "gemini-cli", "cursor", "vscode", "ai-agent", "ai-coding", "coding-agent", "toast", "ntfy", "push-notifications", "desktop-notifications", "hooks", "developer-tools", "cross-platform", "cli", "productivity"],
   "commands": [

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,10 @@ name: Release
 #
 # Auth is TOKENLESS via npm Trusted Publishing (OIDC) — there is NO long-lived
 # NPM_TOKEN secret to store, rotate, or leak. The maintainer configures a
-# Trusted Publisher once at npmjs.com → the ai-agent-notifier package → Settings
+# Trusted Publisher once at npmjs.com → the anotifier package → Settings
 # → Trusted Publisher → GitHub Actions, with:
 #   Organization/user: DevinoSolutions
-#   Repository:        ai-agent-notifier
+#   Repository:        anotifier-for-claude-codex-cursor
 #   Workflow filename: release.yml
 # npm then trusts a short-lived OIDC token minted by THIS workflow (id-token:
 # write) and no other. Provenance attestations are generated automatically.

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 node_modules/
 assets/icon.png
 *.backup
-.ai-agent-notifier-backup
+.anotifier-backup
 
 # Local secrets — never commit
 .env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to `ai-agent-notifier` are documented here. This project
+All notable changes to `anotifier` are documented here. This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
 
@@ -9,13 +9,23 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the
 **First release published to npm since 1.0.6.** Everything in 1.1.0 and 1.2.0
 below ships to npm users for the first time with this release.
 
+### Renamed
+- The package is now **`anotifier`** (was `ai-agent-notifier`), the CLI command
+  is now **`anotifier`**, the config directory is now **`~/.anotifier`** (was
+  `~/.ai-agent-notifier`), and the project home is **https://anotifier.io**. The
+  repository was renamed to `anotifier-for-claude-codex-cursor`.
+- **Upgrading from `ai-agent-notifier`?** Re-run setup — `npx anotifier@latest
+  setup` — because the command name and config directory changed. Prior config
+  is not auto-migrated; the old `ai-agent-notifier` package is deprecated and
+  points here.
+
 ### Fixed
 - **Linux toasts silently dropped for messages starting with `-`.** `notify-send`
   was invoked positionals-first with no `--` end-of-options guard, so rich
   content beginning with a dash (e.g. an assistant line like `- Fixed the bug`)
   was parsed as an unknown option and the toast never fired. Arguments are now
   options, then `--`, then title/message.
-- **`aan test ntfy` crashed on a scheme-less server value.** An unguarded
+- **`anotifier test ntfy` crashed on a scheme-less server value.** An unguarded
   `new URL()` broke the ntfy sender's resolve-false/never-throw contract; a typo
   like `ntfy.sh` (no `https://`) now degrades cleanly instead of throwing.
 - **Update-check nagged a downgrade.** The version comparison used string
@@ -28,8 +38,8 @@ below ships to npm users for the first time with this release.
 - **Real install one-liners.** `setup/install.sh` and `setup/install.ps1` now
   exist — the README `curl | bash` / `irm | iex` commands previously 404'd and
   silently no-opped. Both preflight Node ≥ 18 + npm, fail loudly, and hand off
-  to `npx ai-agent-notifier@latest setup`.
-- **`aan doctor --deep` verifies delivery on Linux.** Fires the real toast with
+  to `npx anotifier@latest setup`.
+- **`anotifier doctor --deep` verifies delivery on Linux.** Fires the real toast with
   a unique marker and reads it back out of `dunst`'s own history, degrading
   honestly (dispatched-but-unverified) when no reader daemon is present. The
   win32 backend check is now a real probe (PowerShell + BurntToast + execution

--- a/LICENSE
+++ b/LICENSE
@@ -629,7 +629,7 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    ai-agent-notifier - Desktop & phone notifications for AI coding agents
+    anotifier - Desktop & phone notifications for AI coding agents
     Copyright (C) 2026 DevinoSolutions
 
     This program is free software: you can redistribute it and/or modify

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">ai-agent-notifier</h1>
+<h1 align="center">anotifier</h1>
 
 <p align="center">
   <strong>Desktop & phone notifications for AI coding agents</strong><br />
@@ -14,9 +14,14 @@
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/ai-agent-notifier"><img src="https://img.shields.io/npm/v/ai-agent-notifier?color=cb3837&label=npm" alt="npm version" /></a>
-  <a href="https://www.npmjs.com/package/ai-agent-notifier"><img src="https://img.shields.io/npm/dm/ai-agent-notifier?color=blue" alt="npm downloads" /></a>
-  <a href="https://github.com/DevinoSolutions/ai-agent-notifier/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue" alt="License: AGPL-3.0" /></a>
+  <a href="https://anotifier.io"><strong>anotifier.io</strong></a>
+</p>
+
+<p align="center">
+  <a href="https://anotifier.io"><img src="https://img.shields.io/badge/website-anotifier.io-6c5ce7" alt="anotifier.io" /></a>
+  <a href="https://www.npmjs.com/package/anotifier"><img src="https://img.shields.io/npm/v/anotifier?color=cb3837&label=npm" alt="npm version" /></a>
+  <a href="https://www.npmjs.com/package/anotifier"><img src="https://img.shields.io/npm/dm/anotifier?color=blue" alt="npm downloads" /></a>
+  <a href="https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue" alt="License: AGPL-3.0" /></a>
   <a href="https://nodejs.org"><img src="https://img.shields.io/badge/node-%3E%3D18-brightgreen" alt="Node.js >= 18" /></a>
   <img src="https://img.shields.io/badge/dependencies-zero-success" alt="Zero Dependencies" />
 </p>
@@ -40,7 +45,7 @@ https://github.com/user-attachments/assets/5714b528-7e04-478e-abfd-2a3d05db562c
 ## Quick Start
 
 ```bash
-npx ai-agent-notifier setup
+npx anotifier setup
 ```
 
 That's it. The setup wizard detects your platform and installed AI tools, wires the hooks, and optionally configures phone push notifications. Restart your AI tools to activate.
@@ -56,7 +61,7 @@ That's it. The setup wizard detects your platform and installed AI tools, wires 
 - **Click-to-focus** -- click the toast to jump back to the terminal or VS Code window (Windows)
 - **Codex approval alerts** -- get notified the instant Codex asks for permission, not just when it finishes
 - **Per-tool branded icons** -- each tool gets its own logo in the notification
-- **One unified config** -- shared `~/.ai-agent-notifier/config.json` across all tools
+- **One unified config** -- shared `~/.anotifier/config.json` across all tools
 - **Atomic deduplication** -- prevents double notifications (e.g. Cursor's duplicate hook fires)
 - **Zero dependencies** -- pure Node.js built-ins only, no npm production packages
 
@@ -104,7 +109,7 @@ All four tools are wired automatically by the setup wizard. No manual config edi
 
 ### VS Code Native Support
 
-Claude Code, Codex, and Cursor all run inside VS Code. **ai-agent-notifier** hooks directly into each tool's native hook system -- no VS Code extension required. The setup wizard detects installed tools and patches their configs automatically. Click a notification toast to jump straight back to your VS Code window.
+Claude Code, Codex, and Cursor all run inside VS Code. **anotifier** hooks directly into each tool's native hook system -- no VS Code extension required. The setup wizard detects installed tools and patches their configs automatically. Click a notification toast to jump straight back to your VS Code window.
 
 ## Installation
 
@@ -112,53 +117,53 @@ Claude Code, Codex, and Cursor all run inside VS Code. **ai-agent-notifier** hoo
 
 ```bash
 # One-shot setup (no install needed)
-npx ai-agent-notifier setup
+npx anotifier setup
 
 # Or install globally
-npm i -g ai-agent-notifier
-ai-agent-notifier setup
+npm i -g anotifier
+anotifier setup
 ```
 
 ### Claude Code Plugin
 
 ```
-/install-plugin https://github.com/DevinoSolutions/ai-agent-notifier
+/install-plugin https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor
 ```
 
-Hooks auto-register. Use `/ai-agent-notifier:setup` to wire other tools.
+Hooks auto-register. Use `/anotifier:setup` to wire other tools.
 
 ### Standalone (no npm)
 
 **Windows (PowerShell):**
 ```powershell
-irm https://raw.githubusercontent.com/DevinoSolutions/ai-agent-notifier/main/setup/install.ps1 | iex
+irm https://raw.githubusercontent.com/DevinoSolutions/anotifier-for-claude-codex-cursor/main/setup/install.ps1 | iex
 ```
 
 **macOS / Linux:**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/DevinoSolutions/ai-agent-notifier/main/setup/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/DevinoSolutions/anotifier-for-claude-codex-cursor/main/setup/install.sh | bash
 ```
 
 ## CLI Commands
 
 ```
-ai-agent-notifier setup          # First-time setup wizard
-ai-agent-notifier status         # Show wired tools, config, backends
-ai-agent-notifier test [channel] # Fire test notification (toast | ntfy | webhook | bell | both)
-ai-agent-notifier config         # Interactive settings menu
-ai-agent-notifier uninstall      # Remove hooks from all tools
+anotifier setup          # First-time setup wizard
+anotifier status         # Show wired tools, config, backends
+anotifier test [channel] # Fire test notification (toast | ntfy | webhook | bell | both)
+anotifier config         # Interactive settings menu
+anotifier uninstall      # Remove hooks from all tools
 ```
 
 ## Configuration
 
-Config lives at `~/.ai-agent-notifier/config.json`:
+Config lives at `~/.anotifier/config.json`:
 
 ```json
 {
   "ntfy": {
     "enabled": true,
     "server": "https://ntfy.sh",
-    "topic": "ai-agent-notifier-<random>",
+    "topic": "anotifier-<random>",
     "click": ""
   },
   "toast": {
@@ -248,7 +253,7 @@ Generic POSTs `{title, message, source, project, event, timestamp}` as JSON. `au
 
 Webhook failures are logged with the URL's origin only, never the full URL -- a Slack/Discord webhook URL or a Telegram bot token is a secret, and errors.log can be mirrored to Sentry.
 
-Test it with `ai-agent-notifier test webhook`, or turn it off for one event type with `"events": {"task_complete": {"webhookEnabled": false}}`.
+Test it with `anotifier test webhook`, or turn it off for one event type with `"events": {"task_complete": {"webhookEnabled": false}}`.
 
 ### Rich notification content
 
@@ -274,7 +279,7 @@ Controlled per channel:
 
 ### Error visibility
 
-Hook and channel errors never interrupt your agent -- they're appended to `~/.ai-agent-notifier/errors.log` and surfaced by `npx ai-agent-notifier status`, so a misconfigured toast backend or unreachable ntfy topic shows up as a logged error instead of a silent no-op. Set `sentry.enabled` to `true` (with a `sentry.dsn`) to also mirror those errors to [Sentry](https://sentry.io) through a built-in, zero-dependency envelope client: no SDK is bundled, no telemetry is collected, and nothing leaves your machine unless you opt in -- only error data is sent.
+Hook and channel errors never interrupt your agent -- they're appended to `~/.anotifier/errors.log` and surfaced by `npx anotifier status`, so a misconfigured toast backend or unreachable ntfy topic shows up as a logged error instead of a silent no-op. Set `sentry.enabled` to `true` (with a `sentry.dsn`) to also mirror those errors to [Sentry](https://sentry.io) through a built-in, zero-dependency envelope client: no SDK is bundled, no telemetry is collected, and nothing leaves your machine unless you opt in -- only error data is sent.
 
 ## How It Works
 
@@ -330,10 +335,10 @@ Hook fires (stdin JSON + --source flag)
 ## Uninstall
 
 ```bash
-ai-agent-notifier uninstall
+anotifier uninstall
 ```
 
-Removes all managed hooks from every tool's config. Original configs are backed up at `~/.ai-agent-notifier/backups/`.
+Removes all managed hooks from every tool's config. Original configs are backed up at `~/.anotifier/backups/`.
 
 ## Testing
 
@@ -355,67 +360,67 @@ Each job runs as its own GitHub Actions workflow. The badge in every row is its 
   <tbody>
     <tr>
       <td><strong>Unit</strong></td>
-      <td align="center"><a href="https://github.com/DevinoSolutions/ai-agent-notifier/actions/workflows/unit.yml"><img src="https://github.com/DevinoSolutions/ai-agent-notifier/actions/workflows/unit.yml/badge.svg?branch=main" alt="Unit" /></a></td>
+      <td align="center"><a href="https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor/actions/workflows/unit.yml"><img src="https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor/actions/workflows/unit.yml/badge.svg?branch=main" alt="Unit" /></a></td>
       <td>Linux · macOS · Windows</td>
       <td>The full unit + integration suite against the real exported code (not inline copies)</td>
     </tr>
     <tr>
       <td><strong>E2E real-world</strong></td>
-      <td align="center"><a href="https://github.com/DevinoSolutions/ai-agent-notifier/actions/workflows/e2e.yml"><img src="https://github.com/DevinoSolutions/ai-agent-notifier/actions/workflows/e2e.yml/badge.svg?branch=main" alt="E2E" /></a></td>
+      <td align="center"><a href="https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor/actions/workflows/e2e.yml"><img src="https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor/actions/workflows/e2e.yml/badge.svg?branch=main" alt="E2E" /></a></td>
       <td>Linux · macOS · Windows</td>
       <td>Real <code>setup</code>/<code>uninstall</code> subprocesses against an isolated HOME · real <code>notify.mjs</code> hook invocation per source · <strong>real ntfy.sh round-trip</strong> (push sent, then read back off the server)</td>
     </tr>
     <tr>
       <td><strong>Install + smoke-load</strong></td>
-      <td align="center"><a href="https://github.com/DevinoSolutions/ai-agent-notifier/actions/workflows/agents.yml"><img src="https://github.com/DevinoSolutions/ai-agent-notifier/actions/workflows/agents.yml/badge.svg?branch=main" alt="Agents" /></a></td>
+      <td align="center"><a href="https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor/actions/workflows/agents.yml"><img src="https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor/actions/workflows/agents.yml/badge.svg?branch=main" alt="Agents" /></a></td>
       <td>Linux · macOS · Windows</td>
       <td>Installs the <strong>real</strong> Claude, Codex, Gemini (and Cursor where available) CLIs from npm, asserts they launch, and smoke-loads each hook (Codex classification pinned — drift fails CI)</td>
     </tr>
     <tr>
       <td><strong>Live Claude</strong></td>
-      <td align="center"><a href="https://github.com/DevinoSolutions/ai-agent-notifier/actions/workflows/live-claude.yml"><img src="https://github.com/DevinoSolutions/ai-agent-notifier/actions/workflows/live-claude.yml/badge.svg?branch=main" alt="Live Claude" /></a></td>
+      <td align="center"><a href="https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor/actions/workflows/live-claude.yml"><img src="https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor/actions/workflows/live-claude.yml/badge.svg?branch=main" alt="Live Claude" /></a></td>
       <td>Linux · macOS</td>
       <td>Drives the <strong>real</strong> Claude CLI end to end (paid); <strong>hard-fails</strong> if the Stop hook doesn't deliver a real ntfy push · on macOS it also does a <strong>best-effort</strong> Notification Center read-back (logged, non-blocking — the hard osascript→NC delivery proof is the dedicated Toast macOS lane)</td>
     </tr>
     <tr>
       <td><strong>Live Gemini</strong></td>
-      <td align="center"><a href="https://github.com/DevinoSolutions/ai-agent-notifier/actions/workflows/live-gemini.yml"><img src="https://github.com/DevinoSolutions/ai-agent-notifier/actions/workflows/live-gemini.yml/badge.svg?branch=main" alt="Live Gemini" /></a></td>
+      <td align="center"><a href="https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor/actions/workflows/live-gemini.yml"><img src="https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor/actions/workflows/live-gemini.yml/badge.svg?branch=main" alt="Live Gemini" /></a></td>
       <td>Linux · macOS</td>
       <td>Drives the <strong>real</strong> Gemini CLI end to end; <strong>hard-fails</strong> if the hook doesn't deliver a real ntfy push · on macOS it also does a <strong>best-effort</strong> Notification Center read-back (logged, non-blocking — the hard NC delivery proof is the dedicated Toast macOS lane)</td>
     </tr>
     <tr>
       <td><strong>Live Codex</strong></td>
-      <td align="center"><a href="https://github.com/DevinoSolutions/ai-agent-notifier/actions/workflows/live-codex.yml"><img src="https://github.com/DevinoSolutions/ai-agent-notifier/actions/workflows/live-codex.yml/badge.svg?branch=main" alt="Live Codex" /></a></td>
+      <td align="center"><a href="https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor/actions/workflows/live-codex.yml"><img src="https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor/actions/workflows/live-codex.yml/badge.svg?branch=main" alt="Live Codex" /></a></td>
       <td>Linux · macOS</td>
       <td>Validates <code>OPENAI_API_KEY</code> against the <strong>live OpenAI API</strong>, boots the real Codex config + PermissionRequest hook wiring, and drives a <strong>real completed <code>codex exec</code> turn</strong> (asserts it echoes a unique token) ¹</td>
     </tr>
     <tr>
       <td><strong>Live Cursor</strong></td>
-      <td align="center"><a href="https://github.com/DevinoSolutions/ai-agent-notifier/actions/workflows/live-cursor.yml"><img src="https://github.com/DevinoSolutions/ai-agent-notifier/actions/workflows/live-cursor.yml/badge.svg?branch=main" alt="Live Cursor" /></a></td>
+      <td align="center"><a href="https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor/actions/workflows/live-cursor.yml"><img src="https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor/actions/workflows/live-cursor.yml/badge.svg?branch=main" alt="Live Cursor" /></a></td>
       <td>Linux</td>
       <td>Validates the real Cursor config-patch wiring (BYO key) ¹</td>
     </tr>
     <tr>
       <td><strong>TUI Proofs</strong></td>
-      <td align="center"><a href="https://github.com/DevinoSolutions/ai-agent-notifier/actions/workflows/tui-proofs.yml"><img src="https://github.com/DevinoSolutions/ai-agent-notifier/actions/workflows/tui-proofs.yml/badge.svg?branch=main" alt="TUI Proofs" /></a></td>
+      <td align="center"><a href="https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor/actions/workflows/tui-proofs.yml"><img src="https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor/actions/workflows/tui-proofs.yml/badge.svg?branch=main" alt="TUI Proofs" /></a></td>
       <td>macOS</td>
       <td>Drives the <strong>real</strong> Claude and Codex TUIs in a live <code>tmux</code> session. <strong>F1</strong>: the Claude terminal <strong>bell</strong> sets tmux's <code>window_bell_flag</code>. <strong>F2</strong>: a <strong>real Codex approval modal</strong> appears, our PermissionRequest notification fires, we approve via send-keys, and the guarded command runs — the full approval decision loop that <code>codex exec</code> structurally can't exercise</td>
     </tr>
     <tr>
       <td><strong>Live Toast Linux</strong></td>
-      <td align="center"><a href="https://github.com/DevinoSolutions/ai-agent-notifier/actions/workflows/toast-linux.yml"><img src="https://github.com/DevinoSolutions/ai-agent-notifier/actions/workflows/toast-linux.yml/badge.svg?branch=main" alt="Toast Linux" /></a></td>
+      <td align="center"><a href="https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor/actions/workflows/toast-linux.yml"><img src="https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor/actions/workflows/toast-linux.yml/badge.svg?branch=main" alt="Toast Linux" /></a></td>
       <td>Linux</td>
       <td>Fires through the real <code>notify-send</code> backend into a <strong>real <code>dunst</code> daemon</strong>, then reads its history and asserts it captured the exact title + body — and goes one layer further, proving the notification is <strong>rendered on-screen</strong>: it captures the X display and reads the banner's text back with OCR (nonce present in a during-display frame, absent from the pre-fire frame) ²</td>
     </tr>
     <tr>
       <td><strong>Live Toast macOS</strong><br/>(delivery capture)</td>
-      <td align="center"><a href="https://github.com/DevinoSolutions/ai-agent-notifier/actions/workflows/toast-macos.yml"><img src="https://github.com/DevinoSolutions/ai-agent-notifier/actions/workflows/toast-macos.yml/badge.svg?branch=main" alt="Toast macOS" /></a></td>
+      <td align="center"><a href="https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor/actions/workflows/toast-macos.yml"><img src="https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor/actions/workflows/toast-macos.yml/badge.svg?branch=main" alt="Toast macOS" /></a></td>
       <td>macOS</td>
-      <td>Fires the <strong>real</strong> <code>osascript</code> backend, then <strong>reads the delivery back out of Notification Center's own SQLite DB</strong> and asserts the exact payload was recorded — so it fails when a real user would have seen nothing (the silent-drop an exit-code check misses). Also runs <code>aan doctor --deep</code> as an independent second check</td>
+      <td>Fires the <strong>real</strong> <code>osascript</code> backend, then <strong>reads the delivery back out of Notification Center's own SQLite DB</strong> and asserts the exact payload was recorded — so it fails when a real user would have seen nothing (the silent-drop an exit-code check misses). Also runs <code>anotifier doctor --deep</code> as an independent second check</td>
     </tr>
     <tr>
       <td><strong>Live Toast Native</strong></td>
-      <td align="center"><a href="https://github.com/DevinoSolutions/ai-agent-notifier/actions/workflows/toast-native.yml"><img src="https://github.com/DevinoSolutions/ai-agent-notifier/actions/workflows/toast-native.yml/badge.svg?branch=main" alt="Toast Native" /></a></td>
+      <td align="center"><a href="https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor/actions/workflows/toast-native.yml"><img src="https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor/actions/workflows/toast-native.yml/badge.svg?branch=main" alt="Toast Native" /></a></td>
       <td>Windows</td>
       <td>Fires the <strong>real</strong> BurntToast backend, then <strong>reads the notification back out of the Windows notification platform's own store</strong> (<code>wpndatabase.db</code>) and asserts the exact nonce was recorded in the toast's title <strong>and</strong> body — so it fails when a real user would have seen nothing (the silent-drop an exit-code check misses) ³</td>
     </tr>
@@ -424,9 +429,9 @@ Each job runs as its own GitHub Actions workflow. The badge in every row is its 
 
 ¹ The Live Codex lane completes a real `codex exec` turn, but non-interactive exec structurally can't exercise the **approval decision loop** — with no TTY, codex forces `approval: never` + a read-only sandbox, so the PermissionRequest hook never fires. That loop is proven end to end by the **TUI Proofs** lane (F2), which drives the interactive TUI. Cursor is a GUI editor (BYO key), so its lane validates the live key + real config wiring; its hook **delivery** is fully covered by the unit + e2e suites.
 
-² The on-screen render proof draws the banner with **our** tuned `dunstrc` (large mono font, high contrast) on a **virtual** X display (Xvfb), so it proves the product path renders legible, machine-readable pixels — not that every user's desktop theme renders identically. macOS has no equivalent lane: on the hosted runner a real notification records in Notification Center but never presents a banner, and the accessibility/screen-capture routes are walled off by TCC, so **layer 2 (recorded in Notification Center) is the honest macOS CI ceiling** — on-screen rendering there is a real-machine concern (`npm run toast:demo`), while `aan doctor --deep` verifies real **delivery** on your own machine by reading that same Notification Center database back. See [`docs/research/2026-07-15-layer3-render-proof.md`](docs/research/2026-07-15-layer3-render-proof.md).
+² The on-screen render proof draws the banner with **our** tuned `dunstrc` (large mono font, high contrast) on a **virtual** X display (Xvfb), so it proves the product path renders legible, machine-readable pixels — not that every user's desktop theme renders identically. macOS has no equivalent lane: on the hosted runner a real notification records in Notification Center but never presents a banner, and the accessibility/screen-capture routes are walled off by TCC, so **layer 2 (recorded in Notification Center) is the honest macOS CI ceiling** — on-screen rendering there is a real-machine concern (`npm run toast:demo`), while `anotifier doctor --deep` verifies real **delivery** on your own machine by reading that same Notification Center database back. See [`docs/research/2026-07-15-layer3-render-proof.md`](docs/research/2026-07-15-layer3-render-proof.md).
 
-³ Like macOS, Windows is proven to **layer 2** in CI: the hosted `windows-latest` runner is a headless Session-0 environment with no interactive desktop, so the toast is **recorded** by the Windows notification platform but no banner is presented on a screen. The gate reads the record back out of `wpndatabase.db` (WAL-aware — a freshly fired toast lives in the DB's write-ahead log, so an `immutable=1` open would miss it and falsely report absence) and asserts the exact nonce in the title and body. On-screen rendering is a real-machine concern; for it `aan doctor` runs a **static backend check** (PowerShell + BurntToast + execution-policy state) — Windows has no delivery-record read-back in `--deep`, unlike macOS (Notification Center DB) and Linux (`dunst` history). See [`docs/research/2026-07-15-layer3-render-proof.md`](docs/research/2026-07-15-layer3-render-proof.md).
+³ Like macOS, Windows is proven to **layer 2** in CI: the hosted `windows-latest` runner is a headless Session-0 environment with no interactive desktop, so the toast is **recorded** by the Windows notification platform but no banner is presented on a screen. The gate reads the record back out of `wpndatabase.db` (WAL-aware — a freshly fired toast lives in the DB's write-ahead log, so an `immutable=1` open would miss it and falsely report absence) and asserts the exact nonce in the title and body. On-screen rendering is a real-machine concern; for it `anotifier doctor` runs a **static backend check** (PowerShell + BurntToast + execution-policy state) — Windows has no delivery-record read-back in `--deep`, unlike macOS (Notification Center DB) and Linux (`dunst` history). See [`docs/research/2026-07-15-layer3-render-proof.md`](docs/research/2026-07-15-layer3-render-proof.md).
 
 **WSL** has no row above on purpose. WSL toast routing (PowerShell interop across the `/mnt/c` boundary) is unit-tested for detection and interop invocation (`tests/platforms-wsl.test.mjs`, fully deps-injected), but a hosted CI runner cannot host both a WSL guest and an interactive Windows desktop to prove a toast crosses the boundary and lands — so, matching how the Codex `exec` lane doesn't claim the approval-decision loop (¹), that end-to-end delivery is deliberately **not** asserted here.
 
@@ -440,7 +445,7 @@ npm run toast:demo  # fire real desktop toasts, every event
 
 ### The one thing CI can't prove
 
-CI goes further than "the call returned 0." On **Linux** it reads the payload back out of a real `dunst` daemon **and** captures the X display to OCR the banner's text off the screen — pixels, not just a database row. On **macOS** it reads the delivery back out of Notification Center's own database, and on **Windows** out of the notification platform's `wpndatabase.db` — so a notification that was silently dropped for lack of permission records nothing and turns CI **red** instead of green. What no headless runner can prove is the last millimetre: a human's eyes actually seeing the banner. On macOS and Windows the on-screen banner can't be captured in CI at all (the hosted runner records the notification but never presents it — layer 2 is the ceiling ² ³), and everywhere Do Not Disturb / Focus can suppress the on-screen banner while the notification is still recorded as delivered. So "reached the notification store" is not always "a person saw it." To confirm with your own eyes — and to check your own machine's notification setup — run `npm run toast:demo` and `aan doctor --deep`. `--deep` fires a real test notification and reads it back where the OS allows: on **macOS** from Notification Center's database, on **Linux** from the `dunst` daemon's history (where `dunstctl` is present; other daemons honestly report dispatched-but-unverified). On **Windows**, `aan doctor` runs a static backend check (PowerShell + BurntToast + execution-policy).
+CI goes further than "the call returned 0." On **Linux** it reads the payload back out of a real `dunst` daemon **and** captures the X display to OCR the banner's text off the screen — pixels, not just a database row. On **macOS** it reads the delivery back out of Notification Center's own database, and on **Windows** out of the notification platform's `wpndatabase.db` — so a notification that was silently dropped for lack of permission records nothing and turns CI **red** instead of green. What no headless runner can prove is the last millimetre: a human's eyes actually seeing the banner. On macOS and Windows the on-screen banner can't be captured in CI at all (the hosted runner records the notification but never presents it — layer 2 is the ceiling ² ³), and everywhere Do Not Disturb / Focus can suppress the on-screen banner while the notification is still recorded as delivered. So "reached the notification store" is not always "a person saw it." To confirm with your own eyes — and to check your own machine's notification setup — run `npm run toast:demo` and `anotifier doctor --deep`. `--deep` fires a real test notification and reads it back where the OS allows: on **macOS** from Notification Center's database, on **Linux** from the `dunst` daemon's history (where `dunstctl` is present; other daemons honestly report dispatched-but-unverified). On **Windows**, `anotifier doctor` runs a static backend check (PowerShell + BurntToast + execution-policy).
 
 ## Contributing
 

--- a/assets/windows/focus.vbs
+++ b/assets/windows/focus.vbs
@@ -3,7 +3,7 @@ Set shell = CreateObject("WScript.Shell")
 home = shell.ExpandEnvironmentStrings("%USERPROFILE%")
 ' Try npm global path first, then standalone path
 Dim scriptPath
-scriptPath = home & "\.ai-agent-notifier\assets\windows\focus-window.ps1"
+scriptPath = home & "\.anotifier\assets\windows\focus-window.ps1"
 If Not CreateObject("Scripting.FileSystemObject").FileExists(scriptPath) Then
   ' Resolve from same directory as this VBS
   scriptPath = Replace(WScript.ScriptFullName, WScript.ScriptName, "") & "focus-window.ps1"

--- a/assets/windows/toast.ps1
+++ b/assets/windows/toast.ps1
@@ -21,7 +21,7 @@ if (-not $logo -or -not (Test-Path $logo)) {
   $legacy = Join-Path $PSScriptRoot '..\..\assets\icon.png'
   if (Test-Path $legacy) { $logo = $legacy }
   else {
-    $agentDir = Join-Path $env:USERPROFILE '.ai-agent-notifier'
+    $agentDir = Join-Path $env:USERPROFILE '.anotifier'
     $legacy2 = Join-Path $agentDir 'icon.png'
     if (Test-Path $legacy2) { $logo = $legacy2 }
   }

--- a/cli/config.mjs
+++ b/cli/config.mjs
@@ -100,7 +100,7 @@ export async function run(section) {
   else if (section === 'events') await configEvents(rl, config);
   else if (section === 'sentry') await configSentry(rl, config);
   else {
-    log('\n  ai-agent-notifier config\n', 'bold');
+    log('\n  anotifier config\n', 'bold');
     log('  1. ntfy');
     log('  2. Webhook');
     log('  3. Sounds');

--- a/cli/doctor-checks.mjs
+++ b/cli/doctor-checks.mjs
@@ -1,4 +1,4 @@
-// cli/doctor-checks.mjs — pure diagnostic logic for `aan doctor`. No console I/O;
+// cli/doctor-checks.mjs — pure diagnostic logic for `anotifier doctor`. No console I/O;
 // returns an array of { id, channel, status, detail, hint }. Each check is
 // best-effort and never throws; runChecks aggregates them.
 import os from 'node:os';
@@ -63,7 +63,7 @@ export function windowsToastBackendCheck({ hasBin = has, psRun = defaultPsRun } 
     return {
       id: 'toast-backend', channel: 'toast', status: 'warn',
       detail: `${shell} present but backend probe failed: ${err.message}`,
-      hint: 'run `ai-agent-notifier test toast` to see the real error',
+      hint: 'run `anotifier test toast` to see the real error',
     };
   }
 
@@ -79,7 +79,7 @@ export function windowsToastBackendCheck({ hasBin = has, psRun = defaultPsRun } 
     return {
       id: 'toast-backend', channel: 'toast', status: 'warn',
       detail: `${shell} present, BurntToast module not installed`,
-      hint: 'Install-Module BurntToast -Scope CurrentUser  (or run: ai-agent-notifier setup)',
+      hint: 'Install-Module BurntToast -Scope CurrentUser  (or run: anotifier setup)',
     };
   }
   return { id: 'toast-backend', channel: 'toast', status: 'ok', detail: `${shell} + BurntToast present` };
@@ -113,7 +113,7 @@ function ntfyCheck(config) {
   const ok = config?.ntfy?.enabled && config?.ntfy?.topic;
   return ok
     ? { id: 'ntfy-config', channel: 'ntfy', status: 'ok', detail: `${config.ntfy.server || 'https://ntfy.sh'}/${config.ntfy.topic}` }
-    : { id: 'ntfy-config', channel: 'ntfy', status: 'warn', detail: 'ntfy not configured', hint: 'run: ai-agent-notifier setup' };
+    : { id: 'ntfy-config', channel: 'ntfy', status: 'warn', detail: 'ntfy not configured', hint: 'run: anotifier setup' };
 }
 
 function webhookCheck(config) {
@@ -122,12 +122,12 @@ function webhookCheck(config) {
     const u = new URL(config.webhook.url);
     return { id: 'webhook-config', channel: 'webhook', status: 'ok', detail: u.origin };
   } catch {
-    return { id: 'webhook-config', channel: 'webhook', status: 'fail', detail: 'webhook enabled but URL invalid', hint: 'run: ai-agent-notifier config webhook' };
+    return { id: 'webhook-config', channel: 'webhook', status: 'fail', detail: 'webhook enabled but URL invalid', hint: 'run: anotifier config webhook' };
   }
 }
 
 function configCheck(config, configProblem) {
-  if (configProblem) return { id: 'config', channel: 'config', status: 'fail', detail: configProblem.message, hint: 'fix ~/.ai-agent-notifier/config.json' };
+  if (configProblem) return { id: 'config', channel: 'config', status: 'fail', detail: configProblem.message, hint: 'fix ~/.anotifier/config.json' };
   if (!config || typeof config !== 'object') return { id: 'config', channel: 'config', status: 'fail', detail: 'config did not load' };
   return { id: 'config', channel: 'config', status: 'ok', detail: 'config valid' };
 }
@@ -145,7 +145,7 @@ async function toastAuthCheck(deep, strict) {
   // --deep: fire a real marker toast through the production backend and verify.
   const { sendToast } = await import('../src/platforms/macos.mjs');
   const marker = `aan-doctor-${process.pid}-${Date.now().toString(36)}`;
-  await sendToast({ title: 'ai-agent-notifier', message: `doctor check ${marker}`, toastSound: 'Default' });
+  await sendToast({ title: 'anotifier', message: `doctor check ${marker}`, toastSound: 'Default' });
   const res = await verifyDelivery(marker, { timeoutMs: 15000, pollMs: 1000 });
   if (res.delivered) return { id: 'toast-auth', channel: 'toast', status: 'ok', detail: `delivered + verified in Notification Center (${res.record.app || 'osascript'})` };
   if (res.reason === 'tcc-blocked') {
@@ -209,7 +209,7 @@ export async function linuxDeepToastCheck({
   const marker = `aan-doctor-${process.pid}-${Date.now().toString(36)}`;
   const notification = {
     source: 'claude',
-    title: 'ai-agent-notifier doctor check',
+    title: 'anotifier doctor check',
     message: `test notification ${marker}`,
     priority: 'low', // visible to the user — keep it low-urgency
   };
@@ -236,7 +236,7 @@ export async function linuxDeepToastCheck({
     return {
       id: 'toast-deep', channel: 'toast', status: 'warn',
       detail: 'dunstctl present but its history could not be read (daemon not running on this session bus?)',
-      hint: 'start the dunst daemon, then re-run `ai-agent-notifier doctor --deep`',
+      hint: 'start the dunst daemon, then re-run `anotifier doctor --deep`',
     };
   }
   return {

--- a/cli/doctor.mjs
+++ b/cli/doctor.mjs
@@ -1,4 +1,4 @@
-// cli/doctor.mjs — `aan doctor`: per-channel delivery self-check.
+// cli/doctor.mjs — `anotifier doctor`: per-channel delivery self-check.
 // Flags: --deep (send a real marker toast + verify via NC DB on macOS),
 //        --json (machine output for CI), --strict (deep warns become fails;
 //        also enabled by AAN_DOCTOR_STRICT=1).
@@ -22,7 +22,7 @@ export async function run(...args) {
     process.stdout.write(JSON.stringify({ platform: os.platform(), deep, strict, checks: results }, null, 2) + '\n');
   } else {
     console.log();
-    console.log(`  ${c.bold('ai-agent-notifier')} ${c.accent('doctor')}${deep ? c.muted(' --deep') : ''}`);
+    console.log(`  ${c.bold('anotifier')} ${c.accent('doctor')}${deep ? c.muted(' --deep') : ''}`);
     console.log();
     for (const r of results) {
       const line = `  ${ICON[r.status]} ${c.white((r.channel + ':').padEnd(9))} ${r.detail}`;

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -22,7 +22,7 @@ async function printUpdateBanner(c, updatePromise) {
   const latest = await updatePromise;
   if (latest) {
     console.log(`  ${c.warn('↑')} ${c.warn(`Update available: v${pkg.version} → v${latest}`)}`);
-    console.log(`    ${c.muted('npm i -g ai-agent-notifier@latest')}\n`);
+    console.log(`    ${c.muted('npm i -g anotifier@latest')}\n`);
   }
 }
 
@@ -34,7 +34,7 @@ async function main() {
   const updatePromise = checkForUpdate();
 
   if (command === '--version' || command === '-v' || command === '-V') {
-    console.log(`${c.bold('ai-agent-notifier')} ${c.accent(`v${pkg.version}`)}`);
+    console.log(`${c.bold('anotifier')} ${c.accent(`v${pkg.version}`)}`);
     await printUpdateBanner(c, updatePromise);
     process.exit(0);
   }
@@ -47,7 +47,7 @@ async function main() {
 
   const loader = COMMANDS[command];
   if (!loader) {
-    console.error(`${c.error('Error:')} Unknown command "${command}"\n  Run ${c.muted('ai-agent-notifier --help')} for usage.`);
+    console.error(`${c.error('Error:')} Unknown command "${command}"\n  Run ${c.muted('anotifier --help')} for usage.`);
     process.exit(1);
   }
 
@@ -68,7 +68,7 @@ function printHelp(c, banner) {
   console.log(banner());
   console.log(`  ${c.muted('Cross-platform notifications for AI coding agents')}`);
   console.log();
-  console.log(`  ${c.bold('Usage:')} ${c.white('ai-agent-notifier')} ${c.accent('<command>')} ${c.muted('[options]')}`);
+  console.log(`  ${c.bold('Usage:')} ${c.white('anotifier')} ${c.accent('<command>')} ${c.muted('[options]')}`);
   console.log();
   console.log(`  ${c.bold('Commands:')}`);
   console.log(`    ${c.accent('setup')}             ${c.white('First-time setup wizard')}`);
@@ -80,9 +80,9 @@ function printHelp(c, banner) {
   console.log(`    ${c.muted('--version, -v')}     ${c.white('Show version and check for updates')}`);
   console.log();
   console.log(`  ${c.bold('Examples:')}`);
-  console.log(`    ${c.muted('$')} ${c.white('npx ai-agent-notifier setup')}`);
-  console.log(`    ${c.muted('$')} ${c.white('ai-agent-notifier test toast')}`);
-  console.log(`    ${c.muted('$')} ${c.white('ai-agent-notifier config ntfy')}`);
+  console.log(`    ${c.muted('$')} ${c.white('npx anotifier setup')}`);
+  console.log(`    ${c.muted('$')} ${c.white('anotifier test toast')}`);
+  console.log(`    ${c.muted('$')} ${c.white('anotifier config ntfy')}`);
   console.log();
 }
 

--- a/cli/setup.mjs
+++ b/cli/setup.mjs
@@ -39,7 +39,7 @@ function generateTopic() {
   const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
   let suffix = '';
   for (let i = 0; i < 16; i++) suffix += chars[Math.floor(Math.random() * chars.length)];
-  return `ai-agent-notifier-${suffix}`;
+  return `anotifier-${suffix}`;
 }
 
 function resolveNotifyPath() {
@@ -136,7 +136,7 @@ export async function run() {
     rl = readline.createInterface({ input: process.stdin, output: process.stdout });
   }
 
-  log('\n  ai-agent-notifier — cross-platform AI agent notifications\n', 'bold');
+  log('\n  anotifier — cross-platform AI agent notifications\n', 'bold');
 
   // 1. Platform
   const platLabel = PLATFORM === 'win32' ? 'Windows' : PLATFORM === 'darwin' ? 'macOS' : 'Linux';

--- a/cli/status.mjs
+++ b/cli/status.mjs
@@ -80,7 +80,7 @@ export async function run() {
 
   // Build box content
   const lines = [
-    c.bold(`ai-agent-notifier ${c.accent(`v${pkg.version}`)}`),
+    c.bold(`anotifier ${c.accent(`v${pkg.version}`)}`),
     '',
     kv('Platform', platLabel),
     kv('Toast', `${toastLabel}${toastExtra}`),
@@ -121,7 +121,7 @@ export async function run() {
   if (latest) {
     console.log();
     console.log(`  ${c.warn('↑')} ${c.warn(`Update available: v${pkg.version} → v${latest}`)}`);
-    console.log(`    ${c.muted('npm i -g ai-agent-notifier@latest')}`);
+    console.log(`    ${c.muted('npm i -g anotifier@latest')}`);
   }
   console.log();
 }

--- a/cli/test.mjs
+++ b/cli/test.mjs
@@ -26,7 +26,7 @@ export async function run(channel) {
   }
 
   const testNotif = {
-    title: 'ai-agent-notifier',
+    title: 'anotifier',
     message: 'Test notification — if you see this, it works!',
     toastSound: 'Default',
     priority: 'default',
@@ -35,7 +35,7 @@ export async function run(channel) {
   };
 
   console.log();
-  console.log(`  ${c.bold('ai-agent-notifier')} ${c.accent('test')}`);
+  console.log(`  ${c.bold('anotifier')} ${c.accent('test')}`);
   console.log();
 
   const doToast = !channel || channel === 'toast' || channel === 'both';
@@ -65,7 +65,7 @@ export async function run(channel) {
       if (ok) spin.stop('ntfy sent');
       else { spin.fail('ntfy failed'); failed = true; }
     } else {
-      console.log(`  ${c.warn('⚠')} ${c.muted('ntfy not configured — run')} ${c.white('ai-agent-notifier setup')} ${c.muted('first')}`);
+      console.log(`  ${c.warn('⚠')} ${c.muted('ntfy not configured — run')} ${c.white('anotifier setup')} ${c.muted('first')}`);
     }
   }
 
@@ -76,7 +76,7 @@ export async function run(channel) {
       if (ok) spin.stop('Webhook sent');
       else { spin.fail('Webhook failed'); failed = true; }
     } else {
-      console.log(`  ${c.warn('⚠')} ${c.muted('webhook not configured — run')} ${c.white('ai-agent-notifier config')} ${c.muted('first')}`);
+      console.log(`  ${c.warn('⚠')} ${c.muted('webhook not configured — run')} ${c.white('anotifier config')} ${c.muted('first')}`);
     }
   }
 

--- a/cli/uninstall.mjs
+++ b/cli/uninstall.mjs
@@ -16,14 +16,14 @@ export async function run() {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 
   console.log();
-  console.log(`  ${c.bold('ai-agent-notifier')} ${c.accent('uninstall')}`);
+  console.log(`  ${c.bold('anotifier')} ${c.accent('uninstall')}`);
   console.log();
 
   // Resolve on EOF/close too, so a non-TTY stdin can't hang the prompt forever.
   const answer = await new Promise((resolve) => {
     let done = false;
     const finish = (v) => { if (!done) { done = true; resolve(v); } };
-    rl.question(`  ${c.warn('?')} Remove ai-agent-notifier hooks from all tools? ${c.muted('(y/N)')} `, finish);
+    rl.question(`  ${c.warn('?')} Remove anotifier hooks from all tools? ${c.muted('(y/N)')} `, finish);
     rl.on('close', () => finish(''));
   });
 
@@ -50,7 +50,7 @@ export async function run() {
 
   console.log();
   console.log(`    ${c.muted('Backups saved to')} ${c.white(backupDir)}`);
-  console.log(`    ${c.muted('Config at ~/.ai-agent-notifier/ preserved — delete manually if desired.')}`);
+  console.log(`    ${c.muted('Config at ~/.anotifier/ preserved — delete manually if desired.')}`);
   console.log();
 
   if (anyFailed) process.exitCode = 1;

--- a/cli/update-check.mjs
+++ b/cli/update-check.mjs
@@ -69,7 +69,7 @@ export function isNewer(a, b) {
 // Never throws.
 export function fetchLatest() {
   return new Promise((resolve) => {
-    const req = https.get('https://registry.npmjs.org/ai-agent-notifier/latest', { timeout: 3000 }, (res) => {
+    const req = https.get('https://registry.npmjs.org/anotifier/latest', { timeout: 3000 }, (res) => {
       let data = '';
       res.on('data', (chunk) => { data += chunk; });
       res.on('end', () => {

--- a/commands/config.md
+++ b/commands/config.md
@@ -3,7 +3,7 @@ name: config
 description: Open the interactive settings menu to configure notifications
 ---
 
-Open the ai-agent-notifier interactive configuration menu. Execute this in the terminal:
+Open the anotifier interactive configuration menu. Execute this in the terminal:
 
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/cli/index.mjs" config

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -1,9 +1,9 @@
 ---
 name: setup
-description: Set up ai-agent-notifier notifications for all AI tools
+description: Set up anotifier notifications for all AI tools
 ---
 
-Run the ai-agent-notifier setup wizard. Execute this command in the terminal:
+Run the anotifier setup wizard. Execute this command in the terminal:
 
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/cli/index.mjs" setup

--- a/commands/status.md
+++ b/commands/status.md
@@ -3,7 +3,7 @@ name: status
 description: Show which AI tools are wired, notification config, and backend status
 ---
 
-Show the current status of ai-agent-notifier. Execute this in the terminal:
+Show the current status of anotifier. Execute this in the terminal:
 
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/cli/index.mjs" status

--- a/commands/test.md
+++ b/commands/test.md
@@ -1,6 +1,6 @@
 ---
 name: test
-description: Fire a test notification to verify ai-agent-notifier is working
+description: Fire a test notification to verify anotifier is working
 ---
 
 Send a test notification through all enabled channels. Execute this in the terminal:

--- a/commands/uninstall.md
+++ b/commands/uninstall.md
@@ -1,6 +1,6 @@
 ---
 name: uninstall
-description: Remove all ai-agent-notifier hooks from every AI tool
+description: Remove all anotifier hooks from every AI tool
 ---
 
 Remove all managed hooks from every tool's config. Execute this in the terminal:
@@ -9,4 +9,4 @@ Remove all managed hooks from every tool's config. Execute this in the terminal:
 node "${CLAUDE_PLUGIN_ROOT}/cli/index.mjs" uninstall
 ```
 
-This cleanly removes hooks from Claude Code, Codex, Cursor, and Gemini. Original configs are backed up at `~/.ai-agent-notifier/backups/`.
+This cleanly removes hooks from Claude Code, Codex, Cursor, and Gemini. Original configs are backed up at `~/.anotifier/backups/`.

--- a/docs/audits/2026-07-16-final-pass.json
+++ b/docs/audits/2026-07-16-final-pass.json
@@ -16,7 +16,7 @@
     ],
     "checks_failed": [],
     "blocked": [
-      "npm publish of v1.2.1 — requires the maintainer to configure an npm Trusted Publisher (OIDC) for DevinoSolutions/ai-agent-notifier + release.yml at npmjs.com, then push a v1.2.1 tag; auth is tokenless (no NPM_TOKEN secret) and CI must never publish or tag itself (release.yml is the rail, deliberately un-triggered). [Superseded the earlier NPM_TOKEN-secret plan.]",
+      "npm publish of v1.2.1 — requires the maintainer to configure an npm Trusted Publisher (OIDC) for the anotifier package (DevinoSolutions/anotifier-for-claude-codex-cursor) + release.yml at npmjs.com, then push a v1.2.1 tag; auth is tokenless (no NPM_TOKEN secret) and CI must never publish or tag itself (release.yml is the rail, deliberately un-triggered). [Superseded the earlier NPM_TOKEN-secret plan.]",
       "Real WSL toast-to-Windows-host delivery — not provable on a hosted GitHub runner (cannot host a WSL guest and an interactive Windows desktop together); documented as a proof boundary instead",
       "Linux doctor --deep daemon read-back — CLOSED in the follow-up post-audit hardening pass (TC-27 now 'fixed': dunst-history read-back probe + CI gate on toast-linux.yml)"
     ]
@@ -227,10 +227,10 @@
       "title": "npm publish of v1.2.1 to the real user funnel",
       "severity": "high",
       "area": "release-rails",
-      "evidence": "npm latest is 1.0.6; release.yml exists but is un-triggered; an npm Trusted Publisher (OIDC) config and a v1.2.1 tag are prerequisites.",
+      "evidence": "the anotifier package has no published version yet; release.yml exists but is un-triggered; an npm Trusted Publisher (OIDC) config and a v1.2.1 tag are prerequisites.",
       "confidence": "high",
       "status": "deferred",
-      "resolution": "Blocked on maintainer: configure an npm Trusted Publisher (OIDC) for DevinoSolutions/ai-agent-notifier + release.yml at npmjs.com (tokenless — no NPM_TOKEN secret; supersedes the earlier automation-token plan), then `git tag v1.2.1 && git push origin v1.2.1` to trigger release.yml. CI must not tag or publish itself."
+      "resolution": "Blocked on maintainer: configure an npm Trusted Publisher (OIDC) for the anotifier package (DevinoSolutions/anotifier-for-claude-codex-cursor) + release.yml at npmjs.com (tokenless — no NPM_TOKEN secret; supersedes the earlier automation-token plan), then `git tag v1.2.1 && git push origin v1.2.1` to trigger release.yml. CI must not tag or publish itself."
     },
     {
       "id": "TC-27",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "ai-agent-notifier",
+  "name": "anotifier",
   "version": "1.2.1",
   "description": "Desktop & phone notifications for AI coding agents in VS Code and CLI. Supports Claude Code, Codex, Gemini CLI, and Cursor with toast alerts and ntfy push notifications.",
   "type": "module",
   "bin": {
-    "ai-agent-notifier": "cli/index.mjs"
+    "anotifier": "cli/index.mjs"
   },
   "main": "./src/notify.mjs",
   "scripts": {
@@ -39,8 +39,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/DevinoSolutions/ai-agent-notifier.git"
+    "url": "git+https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor.git"
   },
+  "homepage": "https://anotifier.io",
   "license": "AGPL-3.0-or-later",
   "engines": {
     "node": ">=18.0.0"

--- a/scripts/lib/live-driver.mjs
+++ b/scripts/lib/live-driver.mjs
@@ -21,9 +21,9 @@ export function randomTopic(prefix = 'aan-ci') {
   return `${prefix}-${s}`;
 }
 
-// Write ~/.ai-agent-notifier/config.json (merged over defaults by loadConfig).
+// Write ~/.anotifier/config.json (merged over defaults by loadConfig).
 export function writeUserConfig(home, partial) {
-  const dir = path.join(home, '.ai-agent-notifier');
+  const dir = path.join(home, '.anotifier');
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(path.join(dir, 'config.json'), JSON.stringify(partial, null, 2) + '\n');
 }

--- a/scripts/toast-demo.mjs
+++ b/scripts/toast-demo.mjs
@@ -44,7 +44,7 @@ async function main() {
     : platform === 'darwin' ? 'macos.mjs (osascript)'
       : 'linux.mjs (notify-send)';
 
-  const config = loadConfig(); // real merged config (defaults + ~/.ai-agent-notifier)
+  const config = loadConfig(); // real merged config (defaults + ~/.anotifier)
   const sendToast = await resolveToastBackend();
 
   const sources = args.source ? [args.source] : SOURCES;

--- a/scripts/tui/proof-bell.mjs
+++ b/scripts/tui/proof-bell.mjs
@@ -83,8 +83,8 @@ async function main() {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'aan-tui-bell-'));
   fs.mkdirSync(path.join(home, '.claude'), { recursive: true });
   fs.writeFileSync(path.join(home, '.claude', 'settings.json'), '{}\n');
-  fs.mkdirSync(path.join(home, '.ai-agent-notifier'), { recursive: true });
-  fs.writeFileSync(path.join(home, '.ai-agent-notifier', 'config.json'),
+  fs.mkdirSync(path.join(home, '.anotifier'), { recursive: true });
+  fs.writeFileSync(path.join(home, '.anotifier', 'config.json'),
     JSON.stringify({ toast: { enabled: false }, ntfy: { enabled: false }, webhook: { enabled: false }, terminalBell: { enabled: true } }) + '\n');
 
   // claude runs from (and we pre-trust) this exact directory.

--- a/setup/install.ps1
+++ b/setup/install.ps1
@@ -1,14 +1,14 @@
-# setup/install.ps1 — standalone bootstrapper for ai-agent-notifier on Windows.
+# setup/install.ps1 — standalone bootstrapper for anotifier on Windows.
 # Intended to be piped:  irm .../setup/install.ps1 | iex
 # It verifies Node >= 18 and npm are present, then hands off to the real setup
-# wizard via `npx ai-agent-notifier@latest setup`, forwarding any extra args.
+# wizard via `npx anotifier@latest setup`, forwarding any extra args.
 #
 # $ErrorActionPreference = 'Stop' is deliberate: a bootstrapper people pipe into a
 # shell must fail LOUDLY and stop — never silently no-op — if a prerequisite is missing.
 $ErrorActionPreference = 'Stop'
 
 function Fail($msg) {
-  Write-Host "`nai-agent-notifier install failed: $msg" -ForegroundColor Red
+  Write-Host "`nanotifier install failed: $msg" -ForegroundColor Red
   exit 1
 }
 
@@ -26,6 +26,6 @@ if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
   Fail "npm is required but was not found (it ships with Node.js). Reinstall Node 18+ from https://nodejs.org"
 }
 
-Write-Host "Node $(node -v) and npm $(npm -v) detected - launching ai-agent-notifier setup..."
-& npx --yes ai-agent-notifier@latest setup @args
+Write-Host "Node $(node -v) and npm $(npm -v) detected - launching anotifier setup..."
+& npx --yes anotifier@latest setup @args
 exit $LASTEXITCODE

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
-# setup/install.sh — standalone bootstrapper for ai-agent-notifier (no git clone).
+# setup/install.sh — standalone bootstrapper for anotifier (no git clone).
 # Intended to be piped:  curl -fsSL .../setup/install.sh | bash
 # It verifies Node >= 18 and npm are present, then hands off to the real setup
-# wizard via `npx ai-agent-notifier@latest setup`, forwarding any extra args.
+# wizard via `npx anotifier@latest setup`, forwarding any extra args.
 #
 # `set -euo pipefail` is deliberate: a bootstrapper people pipe into a shell must
 # fail LOUDLY and stop — never silently no-op — if a prerequisite is missing.
 set -euo pipefail
 
 err() {
-  printf '\n\033[31mai-agent-notifier install failed:\033[0m %s\n' "$1" >&2
+  printf '\n\033[31manotifier install failed:\033[0m %s\n' "$1" >&2
   exit 1
 }
 
@@ -29,5 +29,5 @@ if ! command -v npm >/dev/null 2>&1; then
   err "npm is required but was not found (it ships with Node.js). Reinstall Node 18+ from https://nodejs.org"
 fi
 
-echo "Node $(node -v) and npm $(npm -v) detected — launching ai-agent-notifier setup..."
-exec npx --yes ai-agent-notifier@latest setup "$@"
+echo "Node $(node -v) and npm $(npm -v) detected — launching anotifier setup..."
+exec npx --yes anotifier@latest setup "$@"

--- a/setup/patch-config.mjs
+++ b/setup/patch-config.mjs
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import crypto from 'node:crypto';
 import path from 'node:path';
 
-const MANAGED_TAG = 'ai-agent-notifier';
+const MANAGED_TAG = 'anotifier';
 
 // Single source of truth for which hook events each tool's patcher writes.
 // unpatchAll cleans EXACTLY these events, so patch and unpatch can never diverge
@@ -77,7 +77,7 @@ function makeHookEntry(notifyPath, source, { tag = true, timeout = 10, statusMes
 
 function isOurHook(command) {
   return command?.includes('notify.mjs') &&
-    (command.includes('ai-agent-notifier') || command.includes('agent-notify'));
+    (command.includes('anotifier') || command.includes('agent-notify'));
 }
 
 // The ONE predicate that decides whether a hook-array entry is ours. Covers all
@@ -95,7 +95,7 @@ export function isManagedHookEntry(entry) {
 }
 
 // Event names in a tool's hooks object that contain at least one managed entry.
-// This is the single detection used by `ai-agent-notifier status`.
+// This is the single detection used by `anotifier status`.
 export function detectManagedEvents(hooksObject) {
   if (!hooksObject || typeof hooksObject !== 'object') return [];
   return Object.keys(hooksObject).filter((event) =>

--- a/src/config-loader.mjs
+++ b/src/config-loader.mjs
@@ -23,7 +23,7 @@ function deepMerge(a, b) {
 }
 
 export function getConfigDir() {
-  return path.join(os.homedir(), '.ai-agent-notifier');
+  return path.join(os.homedir(), '.anotifier');
 }
 
 export function getConfigPath() {

--- a/src/error-log.mjs
+++ b/src/error-log.mjs
@@ -1,7 +1,7 @@
 // src/error-log.mjs — Error visibility for the hook path.
 // The hook must never crash the host agent, but failures must never be
-// invisible either: every error is appended to ~/.ai-agent-notifier/errors.log
-// (bounded size), surfaced by `ai-agent-notifier status`, and mirrored to
+// invisible either: every error is appended to ~/.anotifier/errors.log
+// (bounded size), surfaced by `anotifier status`, and mirrored to
 // Sentry when the user opted in via config.sentry.
 import fs from 'node:fs';
 import os from 'node:os';
@@ -14,7 +14,7 @@ let sentryConfig = null;
 const pendingSentrySends = [];
 
 export function getErrorLogPath(baseDir = os.homedir()) {
-  return path.join(baseDir, '.ai-agent-notifier', 'errors.log');
+  return path.join(baseDir, '.anotifier', 'errors.log');
 }
 
 // Call once per process (from the hook entry point or a CLI command) with

--- a/src/notify.mjs
+++ b/src/notify.mjs
@@ -27,7 +27,7 @@ export function dedupKey(event) {
 }
 
 export function acquireNotifyLock(key, baseDir = os.homedir()) {
-  const dir = path.join(baseDir, '.ai-agent-notifier');
+  const dir = path.join(baseDir, '.anotifier');
   const lockFile = path.join(dir, `.lock-${key}`);
   try { fs.mkdirSync(dir, { recursive: true }); } catch {}
   // Clean up locks older than the dedup window (locks are never released —

--- a/src/ntfy.mjs
+++ b/src/ntfy.mjs
@@ -31,7 +31,7 @@ export function sendNtfy(ntfyConfig, notification) {
 
     // A bare-hostname typo (server: "ntfy.sh" with no scheme) makes `new URL`
     // throw, which would break this module's resolve-false-never-throw contract
-    // and crash `aan test ntfy` with a raw "Invalid URL" (mirrors webhook.mjs).
+    // and crash `anotifier test ntfy` with a raw "Invalid URL" (mirrors webhook.mjs).
     let parsed;
     try {
       parsed = new URL(url);

--- a/src/platforms/macos-delivery.mjs
+++ b/src/platforms/macos-delivery.mjs
@@ -2,7 +2,7 @@
 //
 // Delivery verification for macOS notifications. Zero-dependency: shells out to
 // the preinstalled `sqlite3`, `plutil`, and `getconf`. Every function returns a
-// structured result and NEVER throws — callers (aan doctor, CI lanes) decide
+// structured result and NEVER throws — callers (anotifier doctor, CI lanes) decide
 // severity.
 //
 // The core idea: macOS logs every DELIVERED notification in Notification
@@ -162,7 +162,7 @@ export async function verifyDelivery(marker, { timeoutMs = 30000, pollMs = 1000 
 // a community-reverse-engineered guess, never validated against Apple ground
 // truth (no spike ever confirmed it). So decodeAuthFlags' 'authorized' /
 // 'unauthorized' is a LOW-CONFIDENCE diagnostic hint only: it is not consumed by
-// any CI gate or hard `aan doctor` pass/fail. Delivery is proven by the NC record
+// any CI gate or hard `anotifier doctor` pass/fail. Delivery is proven by the NC record
 // check in verifyDelivery, not by this bit; doctor treats a non-'authorized'
 // state as a soft 'warn' at most.
 //

--- a/tests/cli-test.test.mjs
+++ b/tests/cli-test.test.mjs
@@ -1,4 +1,4 @@
-// tests/cli-test.test.mjs — `aan test <channel>` argument validation.
+// tests/cli-test.test.mjs — `anotifier test <channel>` argument validation.
 // The unknown-channel path must fail loudly (exit 1) instead of printing the
 // header and exiting 0, which reads as a silent success.
 import { test } from 'node:test';

--- a/tests/config-loader.test.mjs
+++ b/tests/config-loader.test.mjs
@@ -5,8 +5,8 @@ import path from 'node:path';
 import os from 'node:os';
 
 // We'll test with a temp dir as home
-const tmpDir = path.join(os.tmpdir(), 'ai-agent-notifier-test-' + Date.now());
-const configDir = path.join(tmpDir, '.ai-agent-notifier');
+const tmpDir = path.join(os.tmpdir(), 'anotifier-test-' + Date.now());
+const configDir = path.join(tmpDir, '.anotifier');
 const configPath = path.join(configDir, 'config.json');
 
 describe('config-loader', () => {
@@ -60,9 +60,9 @@ describe('config-loader', () => {
     assert.equal(raw.ntfy.topic, 'saved-topic');
   });
 
-  it('getConfigDir returns ~/.ai-agent-notifier', async () => {
+  it('getConfigDir returns ~/.anotifier', async () => {
     const { getConfigDir } = await import('../src/config-loader.mjs');
     const dir = getConfigDir();
-    assert.ok(dir.endsWith('.ai-agent-notifier'));
+    assert.ok(dir.endsWith('.anotifier'));
   });
 });

--- a/tests/e2e/helpers.mjs
+++ b/tests/e2e/helpers.mjs
@@ -61,7 +61,7 @@ export function seedTempHome() {
 // window. Lock files are keyed `.lock-<source>-<event>[-<session>]`, so clear
 // every lock belonging to the source.
 export function clearLock(home, source) {
-  const dir = path.join(home, '.ai-agent-notifier');
+  const dir = path.join(home, '.anotifier');
   try {
     for (const name of fs.readdirSync(dir)) {
       if (name.startsWith(`.lock-${source}`)) {

--- a/tests/e2e/helpers.test.mjs
+++ b/tests/e2e/helpers.test.mjs
@@ -51,7 +51,7 @@ describe('seedTempHome + writeUserConfig', () => {
     const home = seedTempHome();
     try {
       writeUserConfig(home, { ntfy: { topic: 'xyz' } });
-      const cfg = JSON.parse(fs.readFileSync(path.join(home, '.ai-agent-notifier', 'config.json'), 'utf8'));
+      const cfg = JSON.parse(fs.readFileSync(path.join(home, '.anotifier', 'config.json'), 'utf8'));
       assert.equal(cfg.ntfy.topic, 'xyz');
     } finally {
       fs.rmSync(home, { recursive: true, force: true });
@@ -63,7 +63,7 @@ describe('clearLock', () => {
   it('removes an existing lock and is a no-op when missing', () => {
     const home = seedTempHome();
     try {
-      const dir = path.join(home, '.ai-agent-notifier');
+      const dir = path.join(home, '.anotifier');
       fs.mkdirSync(dir, { recursive: true });
       const lock = path.join(dir, '.lock-claude');
       fs.writeFileSync(lock, '123');

--- a/tests/e2e/ntfy-roundtrip.e2e.test.mjs
+++ b/tests/e2e/ntfy-roundtrip.e2e.test.mjs
@@ -17,9 +17,9 @@ describe('ntfy round-trip via `test ntfy`', () => {
 
     const msg = await ntfyPoll({
       topic,
-      match: (m) => m.title === 'ai-agent-notifier' && /Test notification/.test(m.message || ''),
+      match: (m) => m.title === 'anotifier' && /Test notification/.test(m.message || ''),
     });
     assert.ok(msg, 'expected the test notification to arrive at ntfy.sh');
-    assert.equal(msg.title, 'ai-agent-notifier');
+    assert.equal(msg.title, 'anotifier');
   });
 });

--- a/tests/e2e/setup.e2e.test.mjs
+++ b/tests/e2e/setup.e2e.test.mjs
@@ -21,7 +21,7 @@ describe('real setup subprocess wires every detected tool', () => {
     assert.equal(res.status, 0, `setup exited non-zero: ${res.stderr}`);
 
     // Config saved with our topic
-    const cfg = readJSON(path.join(home, '.ai-agent-notifier', 'config.json'));
+    const cfg = readJSON(path.join(home, '.anotifier', 'config.json'));
     assert.equal(cfg.ntfy.topic, topic);
 
     // Claude

--- a/tests/notify-dedup.test.mjs
+++ b/tests/notify-dedup.test.mjs
@@ -45,7 +45,7 @@ describe('acquireNotifyLock window', () => {
 
   it('re-acquires once the lock is older than the ~1.5s window', () => {
     assert.equal(acquireNotifyLock('claude-task_complete', base), true);
-    const lock = path.join(base, '.ai-agent-notifier', '.lock-claude-task_complete');
+    const lock = path.join(base, '.anotifier', '.lock-claude-task_complete');
     const past = new Date(Date.now() - 2000);
     fs.utimesSync(lock, past, past);
     assert.equal(acquireNotifyLock('claude-task_complete', base), true, 'stale lock is replaced');
@@ -55,7 +55,7 @@ describe('acquireNotifyLock window', () => {
     // Occupy the config-dir path with a FILE so mkdir and the exclusive create
     // both fail with something other than EEXIST. A broken filesystem must
     // yield a (possibly duplicate) notification, never silence forever.
-    fs.writeFileSync(path.join(base, '.ai-agent-notifier'), 'not a directory');
+    fs.writeFileSync(path.join(base, '.anotifier'), 'not a directory');
     assert.equal(acquireNotifyLock('claude-task_complete', base), true);
   });
 });

--- a/tests/notify-rich.test.mjs
+++ b/tests/notify-rich.test.mjs
@@ -36,7 +36,7 @@ function writeTranscript(home) {
 
 function mkHome(ntfyConfig) {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'aan-notify-rich-'));
-  const cfgDir = path.join(home, '.ai-agent-notifier');
+  const cfgDir = path.join(home, '.anotifier');
   fs.mkdirSync(cfgDir, { recursive: true });
   // Only ntfy is live; toast and bell are off so the run is deterministic.
   fs.writeFileSync(path.join(cfgDir, 'config.json'), JSON.stringify({

--- a/tests/notify-subprocess.test.mjs
+++ b/tests/notify-subprocess.test.mjs
@@ -21,7 +21,7 @@ const ALL_DISABLED = { toast: { enabled: false }, ntfy: { enabled: false }, term
 
 function runNotify(input, source = 'claude', extraArgs = [], config = ALL_DISABLED) {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'aan-notify-sub-'));
-  const cfgDir = path.join(home, '.ai-agent-notifier');
+  const cfgDir = path.join(home, '.anotifier');
   fs.mkdirSync(cfgDir, { recursive: true });
   fs.writeFileSync(path.join(cfgDir, 'config.json'), JSON.stringify(config));
   const env = { ...process.env, HOME: home, USERPROFILE: home };
@@ -62,7 +62,7 @@ describe('notify.mjs subprocess robustness (a hook must never crash)', () => {
       env, encoding: 'utf8', timeout: 30000,
     });
     assert.equal(res.status, 0, res.stderr);
-    const log = fs.readFileSync(path.join(home, '.ai-agent-notifier', 'errors.log'), 'utf8');
+    const log = fs.readFileSync(path.join(home, '.anotifier', 'errors.log'), 'utf8');
     assert.match(log, /"context":"router"/);
     assert.match(log, /PreToolUse/);
     fs.rmSync(home, { recursive: true, force: true });
@@ -84,7 +84,7 @@ describe('notify.mjs subprocess robustness (a hook must never crash)', () => {
     // Unlike runNotify (which seeds a valid config and deletes the home), this test
     // keeps its own home so it can read back the JSONL error log afterward.
     const home = fs.mkdtempSync(path.join(os.tmpdir(), 'aan-notify-badcfg-'));
-    const cfgDir = path.join(home, '.ai-agent-notifier');
+    const cfgDir = path.join(home, '.anotifier');
     fs.mkdirSync(cfgDir, { recursive: true });
     // Deliberately invalid JSON: the loader must fall back to defaults, keep the
     // hook alive (exit 0 + valid JSON), and record the parse failure to errors.log.
@@ -137,7 +137,7 @@ describe('notify.mjs claude terminalSequence bell (F1)', () => {
     // Both invocations must share one HOME so the second collides with the
     // first's dedup lock — runNotify makes a fresh HOME per call, so spawn here.
     const home = fs.mkdtempSync(path.join(os.tmpdir(), 'aan-notify-dedup-'));
-    const cfgDir = path.join(home, '.ai-agent-notifier');
+    const cfgDir = path.join(home, '.anotifier');
     fs.mkdirSync(cfgDir, { recursive: true });
     fs.writeFileSync(
       path.join(cfgDir, 'config.json'),

--- a/tests/notify-unit.test.mjs
+++ b/tests/notify-unit.test.mjs
@@ -16,7 +16,7 @@ describe('acquireNotifyLock (real exported function)', () => {
 
   it('first acquire for a source succeeds', () => {
     assert.equal(acquireNotifyLock('claude', base), true);
-    const lock = path.join(base, '.ai-agent-notifier', '.lock-claude');
+    const lock = path.join(base, '.anotifier', '.lock-claude');
     assert.ok(fs.existsSync(lock));
     assert.equal(fs.readFileSync(lock, 'utf8'), String(process.pid));
   });
@@ -33,7 +33,7 @@ describe('acquireNotifyLock (real exported function)', () => {
 
   it('cleans a stale lock (>10s old) and re-acquires', () => {
     assert.equal(acquireNotifyLock('claude', base), true);
-    const lock = path.join(base, '.ai-agent-notifier', '.lock-claude');
+    const lock = path.join(base, '.anotifier', '.lock-claude');
     const past = new Date(Date.now() - 15000);
     fs.utimesSync(lock, past, past);
     assert.equal(acquireNotifyLock('claude', base), true, 'stale lock should be cleaned and re-acquired');
@@ -48,7 +48,7 @@ describe('acquireNotifyLock (real exported function)', () => {
   it('creates the lock directory if it does not exist', () => {
     const nested = path.join(base, 'does', 'not', 'exist');
     assert.equal(acquireNotifyLock('gemini', nested), true);
-    assert.ok(fs.existsSync(path.join(nested, '.ai-agent-notifier', '.lock-gemini')));
+    assert.ok(fs.existsSync(path.join(nested, '.anotifier', '.lock-gemini')));
   });
 });
 

--- a/tests/ntfy-send.test.mjs
+++ b/tests/ntfy-send.test.mjs
@@ -80,7 +80,7 @@ describe('sendNtfy (real local HTTP server, no mocking)', () => {
 
   it('returns false (never throws) when the server is a bare hostname with no scheme', async () => {
     // A "ntfy.sh" typo (no https://) makes `new URL` throw; the resolve-false
-    // contract must hold so `aan test ntfy` reports cleanly instead of crashing.
+    // contract must hold so `anotifier test ntfy` reports cleanly instead of crashing.
     const ok = await sendNtfy({ server: 'ntfy.sh', topic: 't' }, { title: 'T', message: 'm' });
     assert.equal(ok, false);
   });

--- a/tests/patch-config-advanced.test.mjs
+++ b/tests/patch-config-advanced.test.mjs
@@ -100,7 +100,7 @@ describe('unpatchAll', () => {
         PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'echo safety' }] }],
       }
     }));
-    patchClaude(claudeDir, '/home/user/.npm/ai-agent-notifier/src/notify.mjs');
+    patchClaude(claudeDir, '/home/user/.npm/anotifier/src/notify.mjs');
     // Verify hooks were added
     let settings = JSON.parse(fs.readFileSync(path.join(claudeDir, 'settings.json'), 'utf8'));
     assert.ok(settings.hooks.Stop.length > 0);
@@ -117,7 +117,7 @@ describe('unpatchAll', () => {
     const { patchCodex, unpatchAll } = await import('../setup/patch-config.mjs');
     const codexDir = path.join(tmpDir, '.codex');
     fs.mkdirSync(codexDir, { recursive: true });
-    patchCodex(codexDir, '/home/user/.npm/ai-agent-notifier/src/notify.mjs');
+    patchCodex(codexDir, '/home/user/.npm/anotifier/src/notify.mjs');
     unpatchAll(tmpDir);
     const hooks = JSON.parse(fs.readFileSync(path.join(codexDir, 'hooks.json'), 'utf8'));
     // Events deleted when empty after removing managed hooks
@@ -147,7 +147,7 @@ describe('corrupt config handling', () => {
     fs.writeFileSync(settingsPath, corrupt);
     // A corrupt real config must NOT be silently overwritten with our hooks.
     assert.throws(
-      () => patchClaude(claudeDir, '/home/user/.npm/ai-agent-notifier/src/notify.mjs'),
+      () => patchClaude(claudeDir, '/home/user/.npm/anotifier/src/notify.mjs'),
       /not valid JSON/,
     );
     // File is byte-for-byte unchanged.
@@ -159,7 +159,7 @@ describe('corrupt config handling', () => {
     const codexDir = path.join(tmpDir, '.codex-empty');
     fs.mkdirSync(codexDir, { recursive: true });
     fs.writeFileSync(path.join(codexDir, 'hooks.json'), '');
-    assert.doesNotThrow(() => patchCodex(codexDir, '/home/user/.npm/ai-agent-notifier/src/notify.mjs'));
+    assert.doesNotThrow(() => patchCodex(codexDir, '/home/user/.npm/anotifier/src/notify.mjs'));
     const result = JSON.parse(fs.readFileSync(path.join(codexDir, 'hooks.json'), 'utf8'));
     assert.ok(result.hooks.Stop);
   });
@@ -172,7 +172,7 @@ describe('corrupt config handling', () => {
       version: 1,
       hooks: { stop: [{ command: 'echo user-hook' }] }
     }));
-    patchCursor(cursorDir, '/home/user/.npm/ai-agent-notifier/src/notify.mjs');
+    patchCursor(cursorDir, '/home/user/.npm/anotifier/src/notify.mjs');
     const result = JSON.parse(fs.readFileSync(path.join(cursorDir, 'hooks.json'), 'utf8'));
     // User hook preserved, our hook added
     assert.equal(result.hooks.stop.length, 2);
@@ -189,7 +189,7 @@ describe('Codex config.toml feature flag', () => {
     const { patchCodex } = await import('../setup/patch-config.mjs');
     const codexDir = path.join(tmpDir, '.codex-no-toml');
     fs.mkdirSync(codexDir, { recursive: true });
-    patchCodex(codexDir, '/home/user/.npm/ai-agent-notifier/src/notify.mjs');
+    patchCodex(codexDir, '/home/user/.npm/anotifier/src/notify.mjs');
     const toml = fs.readFileSync(path.join(codexDir, 'config.toml'), 'utf8');
     assert.ok(toml.includes('[features]'));
     assert.ok(toml.includes('hooks = true'));
@@ -200,7 +200,7 @@ describe('Codex config.toml feature flag', () => {
     const codexDir = path.join(tmpDir, '.codex-deprecated');
     fs.mkdirSync(codexDir, { recursive: true });
     fs.writeFileSync(path.join(codexDir, 'config.toml'), '[features]\ncodex_hooks = true\n');
-    patchCodex(codexDir, '/home/user/.npm/ai-agent-notifier/src/notify.mjs');
+    patchCodex(codexDir, '/home/user/.npm/anotifier/src/notify.mjs');
     const toml = fs.readFileSync(path.join(codexDir, 'config.toml'), 'utf8');
     assert.ok(!toml.includes('codex_hooks'));
     assert.ok(toml.includes('hooks = true'));
@@ -210,8 +210,8 @@ describe('Codex config.toml feature flag', () => {
     const { patchCodex } = await import('../setup/patch-config.mjs');
     const codexDir = path.join(tmpDir, '.codex-rerun');
     fs.mkdirSync(codexDir, { recursive: true });
-    patchCodex(codexDir, '/home/user/.npm/ai-agent-notifier/src/notify.mjs');
-    patchCodex(codexDir, '/home/user/.npm/ai-agent-notifier/src/notify.mjs');
+    patchCodex(codexDir, '/home/user/.npm/anotifier/src/notify.mjs');
+    patchCodex(codexDir, '/home/user/.npm/anotifier/src/notify.mjs');
     const toml = fs.readFileSync(path.join(codexDir, 'config.toml'), 'utf8');
     const matches = toml.match(/hooks = true/g);
     assert.equal(matches.length, 1);
@@ -226,18 +226,18 @@ describe('Windows path normalization', () => {
     const { patchCodex } = await import('../setup/patch-config.mjs');
     const codexDir = path.join(tmpDir, '.codex-winpath');
     fs.mkdirSync(codexDir, { recursive: true });
-    patchCodex(codexDir, 'C:\\Users\\dev\\.npm\\ai-agent-notifier\\src\\notify.mjs');
+    patchCodex(codexDir, 'C:\\Users\\dev\\.npm\\anotifier\\src\\notify.mjs');
     const hooks = JSON.parse(fs.readFileSync(path.join(codexDir, 'hooks.json'), 'utf8'));
     const cmd = hooks.hooks.Stop[0].hooks[0].command;
     assert.ok(!cmd.includes('\\'), `Command should use forward slashes: ${cmd}`);
-    assert.ok(cmd.includes('C:/Users/dev/.npm/ai-agent-notifier'));
+    assert.ok(cmd.includes('C:/Users/dev/.npm/anotifier'));
   });
 
   it('Cursor hooks use forward slashes even with backslash input', async () => {
     const { patchCursor } = await import('../setup/patch-config.mjs');
     const cursorDir = path.join(tmpDir, '.cursor-winpath');
     fs.mkdirSync(cursorDir, { recursive: true });
-    patchCursor(cursorDir, 'C:\\Users\\dev\\ai-agent-notifier\\src\\notify.mjs');
+    patchCursor(cursorDir, 'C:\\Users\\dev\\anotifier\\src\\notify.mjs');
     const hooks = JSON.parse(fs.readFileSync(path.join(cursorDir, 'hooks.json'), 'utf8'));
     const cmd = hooks.hooks.stop[0].command;
     assert.ok(!cmd.includes('\\'), `Command should use forward slashes: ${cmd}`);
@@ -267,7 +267,7 @@ describe('Codex config.toml hooks.state idempotency & repair', () => {
     const { patchCodex } = await import('../setup/patch-config.mjs');
     const codexDir = path.join(tmpDir, '.codex-state-rerun');
     fs.mkdirSync(codexDir, { recursive: true });
-    const notify = '/home/user/.npm/ai-agent-notifier/src/notify.mjs';
+    const notify = '/home/user/.npm/anotifier/src/notify.mjs';
     patchCodex(codexDir, notify);
     patchCodex(codexDir, notify);
     const toml = fs.readFileSync(path.join(codexDir, 'config.toml'), 'utf8');
@@ -284,7 +284,7 @@ describe('Codex config.toml hooks.state idempotency & repair', () => {
     const { patchCodex } = await import('../setup/patch-config.mjs');
     const codexDir = path.join(tmpDir, '.codex-state-repair');
     fs.mkdirSync(codexDir, { recursive: true });
-    const notify = '/home/user/.npm/ai-agent-notifier/src/notify.mjs';
+    const notify = '/home/user/.npm/anotifier/src/notify.mjs';
 
     // A clean install produces three valid managed trust entries; the breakage
     // below only needs the first two (stop, session_start).
@@ -337,7 +337,7 @@ describe('unpatchAll Codex config.toml trust cleanup', () => {
     const home = path.join(tmpDir, 'home-unpatch');
     const codexDir = path.join(home, '.codex');
     fs.mkdirSync(codexDir, { recursive: true });
-    const notify = '/home/user/.npm/ai-agent-notifier/src/notify.mjs';
+    const notify = '/home/user/.npm/anotifier/src/notify.mjs';
     patchCodex(codexDir, notify);
 
     const tomlPath = path.join(codexDir, 'config.toml');

--- a/tests/patch-config-detection.test.mjs
+++ b/tests/patch-config-detection.test.mjs
@@ -11,7 +11,7 @@ import {
   detectManagedEvents, isManagedHookEntry,
 } from '../setup/patch-config.mjs';
 
-const NOTIFY = '/home/user/.npm/ai-agent-notifier/src/notify.mjs';
+const NOTIFY = '/home/user/.npm/anotifier/src/notify.mjs';
 const tmpDir = path.join(os.tmpdir(), 'patch-detect-test-' + Date.now());
 
 describe('isManagedHookEntry (shared predicate)', () => {
@@ -22,7 +22,7 @@ describe('isManagedHookEntry (shared predicate)', () => {
     assert.equal(isManagedHookEntry({ hooks: [{ type: 'command', command: `node "${NOTIFY}"` }] }), true);
   });
   it('matches the _managed_by tag', () => {
-    assert.equal(isManagedHookEntry({ _managed_by: 'ai-agent-notifier', hooks: [] }), true);
+    assert.equal(isManagedHookEntry({ _managed_by: 'anotifier', hooks: [] }), true);
   });
   it('does not match unrelated user hooks', () => {
     assert.equal(isManagedHookEntry({ command: 'echo hi' }), false);

--- a/tests/patch-config.test.mjs
+++ b/tests/patch-config.test.mjs
@@ -99,10 +99,10 @@ describe('patch-config', () => {
     patchClaude(claudeDir, '/path/to/notify.mjs');
     patchClaude(claudeDir, '/path/to/notify.mjs');
     const result = JSON.parse(fs.readFileSync(path.join(claudeDir, 'settings.json'), 'utf8'));
-    // Should have exactly one ai-agent-notifier hook per event, not duplicates
+    // Should have exactly one anotifier hook per event, not duplicates
     const notifHooks = result.hooks.Notification;
     const managedCount = notifHooks.filter(h =>
-      h.hooks?.some(hh => hh.command?.includes('ai-agent-notifier') || hh.command?.includes('notify.mjs'))
+      h.hooks?.some(hh => hh.command?.includes('anotifier') || hh.command?.includes('notify.mjs'))
     ).length;
     assert.equal(managedCount, 1);
   });

--- a/tests/sentry.test.mjs
+++ b/tests/sentry.test.mjs
@@ -31,7 +31,7 @@ describe('buildErrorEvent', () => {
     assert.equal(event.platform, 'node');
     assert.equal(event.level, 'error');
     assert.equal(event.logger, 'toast:windows');
-    assert.match(event.release, /^ai-agent-notifier@\d+\.\d+\.\d+$/);
+    assert.match(event.release, /^anotifier@\d+\.\d+\.\d+$/);
     assert.deepEqual(event.tags, { context: 'toast:windows' });
     assert.equal(event.exception.values[0].type, 'TestError');
     assert.equal(event.exception.values[0].value, 'kaboom');


### PR DESCRIPTION
Rebrands to the real name **anotifier** across four coordinated identities, per the product decision.

## What changed
| Identity | Before | After |
|---|---|---|
| npm package | `ai-agent-notifier` | **`anotifier`** (name is free on npm ✅) |
| CLI command / bin | `ai-agent-notifier` | **`anotifier`** (docs' historical `aan <cmd>` → `anotifier <cmd>`) |
| Config dir | `~/.ai-agent-notifier` | **`~/.anotifier`** |
| GitHub repo | `ai-agent-notifier` | **`anotifier-for-claude-codex-cursor`** |
| Homepage | — | **https://anotifier.io** (README header + `package.json`) |

Also updated: `package.json` repository URL, both `.claude-plugin` manifests, install bootstrappers (`npx anotifier@latest`), the patch-config hook command, `release.yml` Trusted Publisher instructions (repo/package names — **auth stays tokenless OIDC**, unchanged), the forward-looking go-live entries in `docs/audits/2026-07-16-final-pass.json`, `.gitignore`, and the `LICENSE` description line. `CHANGELOG.md` gains a **### Renamed** note.

## Deliberately NOT renamed
Historical `docs/plans`, `docs/specs`, prior audit records, and `graphify-out` (accurate point-in-time artifacts); internal unique-id/topic marker prefixes that merely start with `aan-` (they're identifiers, not commands).

## Breaking change (documented)
Upgrading users must re-run **`npx anotifier@latest setup`** — the command name and config dir changed. Prior config is not auto-migrated (re-setup was already required because the hook command name changed). Old `ai-agent-notifier` package will be deprecated pointing here.

## Verification
- Full suite: **318 tests, 310 pass, 8 platform-skip, 0 fail**
- `npm pack --dry-run`: name `anotifier`, `anotifier-1.2.1.tgz`, bin `anotifier`, 51 files, no leaks
- Plugin manifests lockstep at 1.2.1; `extract-changelog 1.2.1` includes the Renamed note
- Repo-wide sweep: zero `ai-agent-notifier` outside historical `docs/`+`graphify-out/` (and the intentional "was ai-agent-notifier" mentions in CHANGELOG)

## Note on first publish
`anotifier` doesn't exist on npm yet, and npm requires a package to exist before OIDC trusted publishing can be configured — so the **first** publish needs a one-time bootstrap (local `npm publish` or a temporary token), then it's tokenless forever after. Details in the launch handoff.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>