### PR TITLE
chore(release): prep 1.2.2 (first tokenless CI release with provenance)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Desktop & phone notifications for AI coding agents in VS Code and CLI",
-    "version": "1.2.1"
+    "version": "1.2.2"
   },
   "plugins": [{
     "name": "anotifier",
     "source": "./",
     "description": "Desktop & phone notifications for AI coding agents. Supports Claude Code, Codex, Gemini CLI, and Cursor with toast alerts and ntfy push.",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "author": { "name": "DevinoSolutions" },
     "repository": "https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor",
     "license": "AGPL-3.0-or-later",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "anotifier",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Desktop & phone notifications for AI coding agents in VS Code and CLI. Supports Claude Code, Codex, Gemini CLI, and Cursor.",
   "author": {
     "name": "DevinoSolutions",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to `anotifier` are documented here. This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
 
+## [1.2.2] — 2026-07-20
+
+Release-infrastructure only — **no functional or behavioral changes from 1.2.1**;
+the package contents are identical.
+
+### Changed
+- **First release published via tokenless CI with provenance.** 1.2.1 was
+  published manually to bootstrap the new `anotifier` package name — npm requires
+  a package to exist before a Trusted Publisher can be configured — so it carries
+  no build provenance. 1.2.2 is the first release cut through GitHub Actions using
+  npm Trusted Publishing (OIDC), so the published artifact now ships with a
+  verifiable provenance attestation, and no npm token is involved at any point.
+
 ## [1.2.1] — 2026-07-16
 
 **First release published to npm since 1.0.6.** Everything in 1.1.0 and 1.2.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anotifier",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Desktop & phone notifications for AI coding agents in VS Code and CLI. Supports Claude Code, Codex, Gemini CLI, and Cursor with toast alerts and ntfy push notifications.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## What

Wires up **1.2.2** so the first tokenless CI release is one `git push` away.

- Bumps `package.json` + `.claude-plugin/{plugin,marketplace}.json` to `1.2.2` (via `npm version`, manifests kept in lockstep).
- Adds the `## [1.2.2]` CHANGELOG section (required — a test guards that CHANGELOG has a section for `package.json`s version, and `release.yml` extracts it for the GitHub release body).

## Why

`1.2.1` was published **manually** to bootstrap the new `anotifier` package name (npm requires a package to exist before a Trusted Publisher can be configured), so it carries **no provenance**. `1.2.2` is the first release cut through GitHub Actions using **npm Trusted Publishing (OIDC)**, so the published artifact ships with a verifiable **provenance attestation** — and no npm token is ever stored.

**No functional or behavioral changes from 1.2.1** — package contents are identical.

## Release steps (after this merges)

1. Configure the Trusted Publisher on npmjs.com (org `DevinoSolutions`, repo `anotifier-for-claude-codex-cursor`, workflow `release.yml`).
2. `git tag v1.2.2 && git push --tags` → CI publishes tokenless with provenance and drafts the GitHub release.

CI never tags or publishes on its own — the maintainer cuts the tag.