### PR TITLE
feat: snooze command + quiet hours + stale update-banner fix

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -15,6 +15,7 @@
     "./commands/status.md",
     "./commands/test.md",
     "./commands/config.md",
+    "./commands/snooze.md",
     "./commands/uninstall.md"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -160,8 +160,12 @@ anotifier status           # Show wired tools, config, backends
 anotifier test [channel]   # Fire test notification (toast | ntfy | webhook | bell | both)
 anotifier config [section] # Interactive settings (ntfy | webhook | sounds | events | sentry)
 anotifier doctor [--deep]  # Diagnose delivery per channel (--deep verifies real delivery)
+anotifier snooze [dur]     # Silence every channel for a while (30m | 2h | 90s | 45 = 45 minutes)
+anotifier snooze off       # Cancel the snooze early
 anotifier uninstall        # Remove hooks from all tools
 ```
+
+`anotifier snooze` with no argument prints the current state (`Snoozed until 14:32` or `Not snoozed`); `anotifier status` shows the same thing. A snooze silences **every** channel -- toast, ntfy, webhook and the terminal bell -- until it expires on its own, and it survives across sessions because the deadline is stored in `~/.anotifier/.snooze.json`.
 
 ## Configuration
 
@@ -194,6 +198,11 @@ Config lives at `~/.anotifier/config.json`. Abbreviated — see [config/default-
   "updateCheck": {
     "enabled": true
   },
+  "quietHours": {
+    "enabled": false,
+    "from": "22:00",
+    "to": "08:00"
+  },
   "events": {
     "task_complete": { "toastSound": "IM", "priority": "default" },
     "needs_input": { "toastSound": "Reminder", "priority": "urgent" },
@@ -208,7 +217,31 @@ Config lives at `~/.anotifier/config.json`. Abbreviated — see [config/default-
 }
 ```
 
-`ntfy.click` is the URL opened when you tap a phone notification (empty = no link). `terminalBell` rings the terminal that launched the agent -- for Claude Code (>=2.1.141) it rings through Claude Code's own terminal write path (hook JSON `terminalSequence`), which is safe in tmux, GNU screen, and on Windows per Claude Code's docs; other agents get a direct TTY/console bell. `webhook` posts to Slack, Discord, Telegram, or any URL (see below). `sentry` is opt-in error reporting (see [Error visibility](#error-visibility)). `updateCheck` announces a newly published anotifier through whichever of your toast / ntfy / webhook channels are already on (never the terminal bell) -- it asks the npm registry at most once per day, tells you at most once per version, and stays silent on any error; set `enabled` to `false` to turn it off entirely, and no check or state write happens at all. Per-event `toastSound` names a Windows [BurntToast](https://github.com/Windos/BurntToast) sound; on macOS the name is mapped to the closest built-in system sound (Windows names like `IM`/`Reminder` are translated, and `Default` or unrecognized names fall back to the system default), while on Linux it is ignored; `priority` (`min` / `low` / `default` / `high` / `urgent`) drives both the ntfy push priority and the Linux `notify-send` urgency.
+`ntfy.click` is the URL opened when you tap a phone notification (empty = no link). `terminalBell` rings the terminal that launched the agent -- for Claude Code (>=2.1.141) it rings through Claude Code's own terminal write path (hook JSON `terminalSequence`), which is safe in tmux, GNU screen, and on Windows per Claude Code's docs; other agents get a direct TTY/console bell. `webhook` posts to Slack, Discord, Telegram, or any URL (see below). `sentry` is opt-in error reporting (see [Error visibility](#error-visibility)). `updateCheck` announces a newly published anotifier through whichever of your toast / ntfy / webhook channels are already on (never the terminal bell) -- it asks the npm registry at most once per day, tells you at most once per version, and stays silent on any error; set `enabled` to `false` to turn it off entirely, and no check or state write happens at all. `quietHours` is a recurring nightly version of `snooze` (see [Quiet hours](#quiet-hours)). Per-event `toastSound` names a Windows [BurntToast](https://github.com/Windos/BurntToast) sound; on macOS the name is mapped to the closest built-in system sound (Windows names like `IM`/`Reminder` are translated, and `Default` or unrecognized names fall back to the system default), while on Linux it is ignored; `priority` (`min` / `low` / `default` / `high` / `urgent`) drives both the ntfy push priority and the Linux `notify-send` urgency.
+
+### Quiet hours
+
+Off by default. Set `quietHours.enabled` to `true` and every channel goes silent inside the window, every day:
+
+```json
+{
+  "quietHours": {
+    "enabled": true,
+    "from": "22:00",
+    "to": "08:00"
+  }
+}
+```
+
+- Times are `"HH:MM"` on a 24-hour clock, in your machine's **local** time.
+- The start is inclusive and the end is exclusive: `22:00` is silenced, `08:00` is not.
+- Windows may span midnight. `22:00` -> `08:00` covers 22:00-23:59 **and** 00:00-07:59. A same-day window like `08:00` -> `22:00` works the same way.
+- `from` equal to `to` is a zero-length window and turns the feature **off**, rather than silencing you for a full 24 hours.
+- A time that isn't a valid `HH:MM` disables the whole block instead of falling back to the default window -- a typo should never silence you -- and the problem is reported by `anotifier status`.
+
+`anotifier status` shows the window and whether you are currently inside it.
+
+**How quiet hours and `snooze` interact:** they are independent, and either one alone silences the run -- there is no per-channel scoping, it is all channels or none. A silenced run is silenced completely: no toast, no ntfy push, no webhook POST, no terminal bell, and no update notice either. What does *not* change is the hook contract -- the hook still exits successfully and still returns the response its agent expects, so silencing notifications can never stall or break Claude Code, Codex, Cursor or Gemini CLI. The daily update check simply runs on the next un-silenced run.
 
 ### ntfy -- Phone Push Notifications
 

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // cli/index.mjs
 import { createRequire } from 'node:module';
-import { checkForUpdate } from '../src/update-check.mjs';
+import { checkForUpdate, isNewer } from '../src/update-check.mjs';
 
 const require = createRequire(import.meta.url);
 const pkg = require('../package.json');
@@ -15,12 +15,17 @@ const COMMANDS = {
   test: () => import('./test.mjs'),
   config: () => import('./config.mjs'),
   doctor: () => import('./doctor.mjs'),
+  snooze: () => import('./snooze.mjs'),
   uninstall: () => import('./uninstall.mjs'),
 };
 
 async function printUpdateBanner(c, updatePromise) {
   const latest = await updatePromise;
-  if (latest) {
+  // Re-assert the semver gate instead of trusting the cached hit: the shared
+  // .update-check.json can hold a version recorded BEFORE the user upgraded,
+  // and for the rest of the 24h TTL that would render as "v1.3.0 → v1.3.0".
+  // Same guard maybeNotifyUpdate applies on the hook path.
+  if (latest && isNewer(latest, pkg.version)) {
     console.log(`  ${c.warn('↑')} ${c.warn(`Update available: v${pkg.version} → v${latest}`)}`);
     console.log(`    ${c.muted('npm i -g anotifier@latest')}\n`);
   }
@@ -76,6 +81,7 @@ function printHelp(c, banner) {
   console.log(`    ${c.accent('test')} ${c.muted('[channel]')}    ${c.white('Fire test notification')} ${c.muted('(toast | ntfy | webhook | bell | both)')}`);
   console.log(`    ${c.accent('config')} ${c.muted('[section]')}  ${c.white('Interactive settings')} ${c.muted('(ntfy | webhook | sounds | events | sentry)')}`);
   console.log(`    ${c.accent('doctor')} ${c.muted('[--deep]')}   ${c.white('Diagnose delivery per channel')} ${c.muted('(--deep verifies real delivery)')}`);
+  console.log(`    ${c.accent('snooze')} ${c.muted('<dur|off>')}  ${c.white('Silence every channel for a while')} ${c.muted('(30m | 2h | 90s | 45)')}`);
   console.log(`    ${c.accent('uninstall')}         ${c.white('Remove hooks from all tools')}`);
   console.log(`    ${c.muted('--version, -v')}     ${c.white('Show version and check for updates')}`);
   console.log();

--- a/cli/snooze.mjs
+++ b/cli/snooze.mjs
@@ -1,0 +1,46 @@
+// cli/snooze.mjs — pause every notification channel for a while.
+import { parseDuration, readSnoozeUntil, writeSnoozeUntil, clearSnooze, formatClock } from '../src/suppress.mjs';
+import { c } from './ui.mjs';
+
+const USAGE = 'anotifier snooze <30m | 2h | 90s | 45>   ·   anotifier snooze off';
+
+export async function run(arg) {
+  // No argument — report, don't change anything.
+  if (!arg) {
+    const until = readSnoozeUntil();
+    console.log();
+    if (until) {
+      console.log(`  ${c.warn('⏸')} ${c.white(`Snoozed until ${formatClock(until)}`)} ${c.muted('— all channels silent')}`);
+    } else {
+      console.log(`  ${c.success('✓')} ${c.white('Not snoozed')}`);
+    }
+    console.log();
+    return;
+  }
+
+  if (arg === 'off') {
+    const cleared = clearSnooze();
+    console.log();
+    console.log(cleared
+      ? `  ${c.success('✓')} ${c.white('Snooze cancelled')}`
+      : `  ${c.success('✓')} ${c.muted('Not snoozed — nothing to cancel')}`);
+    console.log();
+    return;
+  }
+
+  // Strict CLI: an unparseable duration is a user error worth failing on, not
+  // something to round to a default. (The hook path is the resilient one.)
+  const ms = parseDuration(arg);
+  if (ms === null) {
+    console.error(`  ${c.error('Invalid duration:')} ${arg}`);
+    console.error(`  ${c.muted(USAGE)}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const until = writeSnoozeUntil(Date.now() + ms);
+  console.log();
+  console.log(`  ${c.warn('⏸')} ${c.white(`Snoozed until ${formatClock(until)}`)} ${c.muted('— all channels silent')}`);
+  console.log(`    ${c.muted('anotifier snooze off')} ${c.muted('to cancel')}`);
+  console.log();
+}

--- a/cli/status.mjs
+++ b/cli/status.mjs
@@ -6,7 +6,8 @@ import { createRequire } from 'node:module';
 import { loadConfigResult } from '../src/config-loader.mjs';
 import { readRecentHookErrors, getErrorLogPath } from '../src/error-log.mjs';
 import { detectManagedEvents } from '../setup/patch-config.mjs';
-import { checkForUpdate } from '../src/update-check.mjs';
+import { checkForUpdate, isNewer } from '../src/update-check.mjs';
+import { readSnoozeUntil, quietHoursWindow, inQuietHours, formatClock } from '../src/suppress.mjs';
 import { c, box, kv, sectionHeader } from './ui.mjs';
 
 const require = createRequire(import.meta.url);
@@ -52,6 +53,19 @@ export async function run() {
     : c.muted('disabled');
   const sentryValue = config.sentry?.enabled ? c.success('enabled') : c.muted('disabled');
 
+  // Both suppression sources, since either one alone silences every channel and
+  // "why did nothing fire?" is exactly the question `status` exists to answer.
+  const snoozedUntil = readSnoozeUntil();
+  const snoozeValue = snoozedUntil ? c.warn(`until ${formatClock(snoozedUntil)}`) : c.muted('off');
+  // quietHoursWindow is null for every reason the window is inert — disabled, a
+  // malformed time, or from === to — so all of them honestly read as 'disabled'.
+  const quietWindow = quietHoursWindow(config.quietHours);
+  const quietValue = !quietWindow
+    ? c.muted('disabled')
+    : inQuietHours(config.quietHours)
+      ? c.warn(`${quietWindow.from}-${quietWindow.to} (active now)`)
+      : c.white(`${quietWindow.from}-${quietWindow.to}`);
+
   // Tools
   const tools = [
     checkTool('.claude', 'Claude Code', 'settings.json'),
@@ -85,6 +99,8 @@ export async function run() {
     kv('Platform', platLabel),
     kv('Toast', `${toastLabel}${toastExtra}`),
     kv('Sentry', sentryValue),
+    kv('Snooze', snoozeValue),
+    kv('Quiet hours', quietValue),
     kv('ntfy', ''),
     `${''.padEnd(15)} ${ntfyValue}`,
     ...(config.webhook?.enabled && config.webhook?.url
@@ -116,9 +132,11 @@ export async function run() {
     console.log(`    ${c.muted('see')} ${c.white(getErrorLogPath())}`);
   }
 
-  // Update check (shares the memoized, cached result with index.mjs)
+  // Update check (shares the memoized, cached result with index.mjs). The
+  // cached hit can predate an upgrade, so the semver gate is re-asserted here
+  // too — otherwise this reads "v1.3.0 → v1.3.0" until the 24h TTL expires.
   const latest = await checkForUpdate();
-  if (latest) {
+  if (latest && isNewer(latest, pkg.version)) {
     console.log();
     console.log(`  ${c.warn('↑')} ${c.warn(`Update available: v${pkg.version} → v${latest}`)}`);
     console.log(`    ${c.muted('npm i -g anotifier@latest')}`);

--- a/commands/snooze.md
+++ b/commands/snooze.md
@@ -1,0 +1,12 @@
+---
+name: snooze
+description: Silence every anotifier channel for a while
+---
+
+Pause notifications. Execute this in the terminal:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/cli/index.mjs" snooze 30m
+```
+
+This silences every channel — toast, ntfy push, webhook, and terminal bell — until the deadline passes. Durations are `30m`, `2h`, `90s`, or a bare number of minutes (`45`). Run it with no duration to see the current state, or `snooze off` to cancel early.

--- a/config/default-config.json
+++ b/config/default-config.json
@@ -27,6 +27,11 @@
   "updateCheck": {
     "enabled": true
   },
+  "quietHours": {
+    "enabled": false,
+    "from": "22:00",
+    "to": "08:00"
+  },
   "events": {
     "task_complete": {
       "toastSound": "IM",

--- a/src/config-loader.mjs
+++ b/src/config-loader.mjs
@@ -46,6 +46,16 @@ const RENAMED_KEYS = {
 const PRIORITY_VALUES = ['min', 'low', 'default', 'high', 'urgent'];
 const FORMAT_VALUES = ['generic', 'slack', 'discord', 'telegram'];
 
+// "HH:MM" on a 24-hour clock → minutes since midnight, or null when unusable.
+// Exported because the quiet-hours window is evaluated at notify time in
+// src/suppress.mjs: one definition keeps the validator and the runtime from
+// disagreeing about what counts as a time.
+export function parseHHMM(value) {
+  if (typeof value !== 'string') return null;
+  const match = /^([01]\d|2[0-3]):([0-5]\d)$/.exec(value.trim());
+  return match ? Number(match[1]) * 60 + Number(match[2]) : null;
+}
+
 // Shallow schema check. Wrong-typed keys are DELETED from the user object
 // (defaults win) and reported, so a bad value can never poison the runtime.
 // Unknown keys are reported but kept — they are usually typos.
@@ -75,6 +85,24 @@ function validateUserConfig(user) {
   checkBlock('webhook', { enabled: 'boolean', url: 'string', format: 'string', chatId: 'string', authorization: 'string', richContent: 'boolean' });
   checkBlock('sentry', { enabled: 'boolean', dsn: 'string' });
   checkBlock('updateCheck', { enabled: 'boolean' });
+
+  // Quiet hours is the one block where a bad value must NOT fall through to the
+  // defaults: silently silencing every channel from 22:00 to 08:00 because a
+  // time string had a typo is the worst failure mode this config has. So an
+  // unusable from/to drops `enabled` too, landing on the default `false`. Runs
+  // BEFORE the checkBlock below, which would otherwise delete a wrong-typed
+  // time before this pass could see it (and let the default window win).
+  const quiet = user.quietHours;
+  if (quiet && typeof quiet === 'object' && !Array.isArray(quiet)) {
+    for (const key of ['from', 'to']) {
+      if (quiet[key] !== undefined && parseHHMM(quiet[key]) === null) {
+        issues.push(`"quietHours.${key}" must be a "HH:MM" 24-hour time, got ${JSON.stringify(quiet[key])} — quiet hours disabled`);
+        delete quiet[key];
+        delete quiet.enabled;
+      }
+    }
+  }
+  checkBlock('quietHours', { enabled: 'boolean', from: 'string', to: 'string' });
 
   // Webhook format is a fixed preset enum (like event priority): an invalid
   // value is dropped so the 'generic' default wins. Telegram addresses the
@@ -154,7 +182,7 @@ function validateUserConfig(user) {
     }
   }
 
-  const knownTop = ['ntfy', 'toast', 'terminalBell', 'webhook', 'sentry', 'updateCheck', 'events', 'sources'];
+  const knownTop = ['ntfy', 'toast', 'terminalBell', 'webhook', 'sentry', 'updateCheck', 'quietHours', 'events', 'sources'];
   for (const key of Object.keys(user)) {
     if (!knownTop.includes(key)) issues.push(`unknown key "${key}"`);
   }

--- a/src/notify.mjs
+++ b/src/notify.mjs
@@ -14,6 +14,7 @@ import { sendBell } from './bell.mjs';
 import { resolveToastBackend } from './platforms/index.mjs';
 import { enableSentryMirror, logHookError, flushErrorReporting } from './error-log.mjs';
 import { maybeNotifyUpdate } from './update-check.mjs';
+import { isSuppressed } from './suppress.mjs';
 
 // Some tools (Cursor) fire the same hook twice simultaneously. Exclusive file
 // creation is the atomic lock that lets only one invocation notify. The key
@@ -115,6 +116,19 @@ async function main() {
     const event = parseInput(raw, args.source, args.event);
     const config = loadConfig();
     enableSentryMirror(config.sentry);
+
+    // An active snooze or quiet-hours window silences EVERY channel. Checked
+    // before the dedup lock and before routing so a suppressed run does the
+    // least possible work, and — the part that matters — falls through to the
+    // plain '{}\n' response below: no toast, no ntfy, no webhook, no bell, and
+    // no claude terminalSequence (which is only set on the successful path
+    // further down). The update notice goes quiet with everything else; its
+    // check simply runs on a later un-suppressed run.
+    if (isSuppressed(config)) {
+      await flushErrorReporting();
+      process.stdout.write('{}\n');
+      process.exit(0);
+    }
 
     // Deduplicate AFTER parsing so the lock can key on source+event+session
     if (!acquireNotifyLock(dedupKey(event))) {

--- a/src/suppress.mjs
+++ b/src/suppress.mjs
@@ -1,0 +1,125 @@
+// src/suppress.mjs — "should this run stay silent?"
+//
+// Two ways to ask for quiet, one gate: an explicit `anotifier snooze <duration>`
+// (a timestamp in a state file next to .update-check.json) and a recurring
+// quietHours window from config.json. Either one alone suppresses, and
+// suppression is ALL-OR-NOTHING across channels — toast, ntfy, webhook and the
+// terminal bell go silent together. Per-channel scoping would mean two
+// suppression sources with different granularity and no honest answer for the
+// update notice, so the simple contract wins: snoozed means silent, period.
+//
+// Everything here is fail-open. A missing, corrupt, unreadable or expired state
+// file reads as "not snoozed": a broken file must never be able to silence the
+// notifier forever.
+import fs from 'node:fs';
+import path from 'node:path';
+import { getConfigDir, parseHHMM } from './config-loader.mjs';
+
+// Same directory and dotfile convention as .update-check.json. A separate file
+// rather than a key in that one: this is user intent with its own lifecycle
+// (written by the CLI, deleted on expiry), not a cache.
+export const SNOOZE_PATH = path.join(getConfigDir(), '.snooze.json');
+
+const UNIT_MS = { s: 1000, m: 60 * 1000, h: 60 * 60 * 1000 };
+// A bare number is minutes — `anotifier snooze 45` is the shape people type first.
+const DURATION_RE = /^(\d+)(s|m|h)?$/;
+
+// "30m" | "2h" | "90s" | "45" → milliseconds, or null when unusable. Zero and
+// negative durations are null too: `snooze 0` is a typo, not a request to be
+// silenced for no time at all, and the CLI should say so rather than write a
+// state file that is already expired.
+export function parseDuration(input) {
+  const match = DURATION_RE.exec(String(input ?? '').trim().toLowerCase());
+  if (!match) return null;
+  const ms = Number(match[1]) * UNIT_MS[match[2] || 'm'];
+  return Number.isFinite(ms) && ms > 0 ? ms : null;
+}
+
+// Local-time HH:MM, for "snoozed until 14:32" in the CLI and status.
+export function formatClock(ms) {
+  const d = new Date(ms);
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+}
+
+// null = there is no state file at all; {} = there is one but nothing usable
+// came out of it. The caller needs to tell those apart only to decide whether
+// there is anything worth unlinking.
+function readState(statePath) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch (err) {
+    return err?.code === 'ENOENT' ? null : {};
+  }
+}
+
+// The active snooze deadline (epoch ms), or null. Opportunistically deletes a
+// state file that is expired or unusable — dead state should not linger in the
+// config dir or show up in `status`. A failed unlink changes nothing: the
+// timestamp check above has already decided the answer.
+export function readSnoozeUntil(statePath = SNOOZE_PATH, now = Date.now()) {
+  const state = readState(statePath);
+  if (state === null) return null;
+  const until = typeof state.until === 'number' && state.until > now ? state.until : null;
+  if (until === null) { try { fs.unlinkSync(statePath); } catch {} }
+  return until;
+}
+
+// Writes the deadline and returns it. Unlike the read path this does NOT
+// swallow failures: it is only ever called from the CLI, where a state file
+// that could not be written must be reported rather than silently ignored.
+export function writeSnoozeUntil(until, statePath = SNOOZE_PATH) {
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  fs.writeFileSync(statePath, JSON.stringify({ until }) + '\n', 'utf8');
+  return until;
+}
+
+// True when a snooze was actually cancelled, false when there was none. Any
+// other failure throws, for the same reason writeSnoozeUntil does.
+export function clearSnooze(statePath = SNOOZE_PATH) {
+  try {
+    fs.unlinkSync(statePath);
+    return true;
+  } catch (err) {
+    if (err?.code === 'ENOENT') return false;
+    throw err;
+  }
+}
+
+// The usable quiet-hours window, or null when the feature is off for any
+// reason: not enabled, a time that is not "HH:MM", or from === to. A
+// zero-length window is deliberately treated as OFF rather than as a
+// 24-hour one — "from 09:00 to 09:00" reads as a mistake, and the failure
+// mode of guessing wrong is silencing every notification all day.
+export function quietHoursWindow(block) {
+  if (!block || block.enabled !== true) return null;
+  const fromMin = parseHHMM(block.from);
+  const toMin = parseHHMM(block.to);
+  if (fromMin === null || toMin === null || fromMin === toMin) return null;
+  return { from: block.from, to: block.to, fromMin, toMin };
+}
+
+// Start inclusive, end exclusive, in LOCAL machine time: 22:00→08:00 silences
+// 22:00 and 07:59 but not 08:00. from > to means the window spans midnight
+// (22:00–23:59 plus 00:00–07:59), which is why the test flips to an OR.
+// `now` is a Date so callers can pin a wall-clock time without depending on the
+// machine's timezone.
+export function inQuietHours(block, now = new Date()) {
+  const window = quietHoursWindow(block);
+  if (!window) return false;
+  const minutes = now.getHours() * 60 + now.getMinutes();
+  return window.fromMin < window.toMin
+    ? minutes >= window.fromMin && minutes < window.toMin
+    : minutes >= window.fromMin || minutes < window.toMin;
+}
+
+// The hook path's single question. Returns null (notify normally) or the reason
+// this run stays silent — snooze wins the tie only because it has to be checked
+// first to expire the file; either source alone is enough.
+export function isSuppressed(config, { statePath = SNOOZE_PATH, now = Date.now() } = {}) {
+  const until = readSnoozeUntil(statePath, now);
+  if (until !== null) return { reason: 'snooze', until };
+  const block = config?.quietHours;
+  if (inQuietHours(block, new Date(now))) return { reason: 'quietHours', from: block.from, to: block.to };
+  return null;
+}

--- a/tests/cli-snooze.test.mjs
+++ b/tests/cli-snooze.test.mjs
@@ -1,0 +1,87 @@
+// tests/cli-snooze.test.mjs — `anotifier snooze` end to end through the real
+// CLI entry point, against a throwaway HOME. Run as a subprocess rather than by
+// importing cli/snooze.mjs directly: the state path is resolved from the home
+// directory, and an in-process test would write a real snooze into the
+// developer's own ~/.anotifier.
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+describe('anotifier snooze (real CLI, throwaway HOME)', () => {
+  let home, statePath;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'aan-cli-snooze-'));
+    statePath = path.join(home, '.anotifier', '.snooze.json');
+    // A fresh update cache keeps every run offline (no registry request).
+    fs.mkdirSync(path.join(home, '.anotifier'), { recursive: true });
+    fs.writeFileSync(path.join(home, '.anotifier', '.update-check.json'),
+      JSON.stringify({ checkedAt: Date.now(), latest: null }));
+  });
+  afterEach(() => fs.rmSync(home, { recursive: true, force: true }));
+
+  const snooze = (...args) => spawnSync(process.execPath, ['cli/index.mjs', 'snooze', ...args], {
+    cwd: repoRoot,
+    env: { ...process.env, HOME: home, USERPROFILE: home },
+    encoding: 'utf8',
+    timeout: 30000,
+  });
+
+  it('reports "Not snoozed" on a machine that never snoozed', () => {
+    const res = snooze();
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /Not snoozed/);
+  });
+
+  it('a duration writes a future deadline the hook path can read back', () => {
+    const before = Date.now();
+    const res = snooze('30m');
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /Snoozed until \d\d:\d\d/);
+    const { until } = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    assert.ok(until >= before + 30 * 60 * 1000, `deadline should be ~30m out, got ${until - before}ms`);
+    assert.ok(until <= Date.now() + 30 * 60 * 1000);
+    // And a bare `snooze` reports it rather than changing it.
+    assert.match(snooze().stdout, /Snoozed until/);
+    assert.equal(JSON.parse(fs.readFileSync(statePath, 'utf8')).until, until, 'reporting must not re-snooze');
+  });
+
+  it('a bare number is minutes, not milliseconds or seconds', () => {
+    const before = Date.now();
+    assert.equal(snooze('45').status, 0);
+    const { until } = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    assert.ok(until >= before + 45 * 60 * 1000 && until <= Date.now() + 45 * 60 * 1000, `got ${until - before}ms`);
+  });
+
+  it('`off` cancels an active snooze and removes the state file', () => {
+    snooze('2h');
+    const res = snooze('off');
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /Snooze cancelled/);
+    assert.equal(fs.existsSync(statePath), false);
+    assert.match(snooze().stdout, /Not snoozed/);
+  });
+
+  it('`off` with nothing to cancel is not an error', () => {
+    const res = snooze('off');
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /nothing to cancel/);
+  });
+
+  // Strict CLI: bad input fails loudly rather than being rounded to a default.
+  for (const bad of ['banana', '0', '-5', '1.5h']) {
+    it(`exits 1 on \`snooze ${bad}\` and writes no state`, () => {
+      const res = snooze(bad);
+      assert.equal(res.status, 1, res.stdout);
+      assert.match(res.stderr, /Invalid duration/);
+      assert.match(res.stderr, new RegExp(bad.replace('.', '\\.')));
+      assert.equal(fs.existsSync(statePath), false, 'a rejected duration must not write a snooze');
+    });
+  }
+});

--- a/tests/config-loader-validation.test.mjs
+++ b/tests/config-loader-validation.test.mjs
@@ -156,6 +156,60 @@ describe('loadConfigResult', () => {
     assert.equal(config.sources.claude.label, 'My Claude');
   });
 
+  it('quietHours: a valid window produces no problem', () => {
+    fs.writeFileSync(configPath, JSON.stringify({
+      quietHours: { enabled: true, from: '23:30', to: '07:15' },
+    }), 'utf8');
+    const { config, problem } = loadConfigResult(configPath);
+    assert.equal(problem, null);
+    assert.deepEqual(config.quietHours, { enabled: true, from: '23:30', to: '07:15' });
+  });
+
+  it('quietHours: defaults to OFF with a 22:00-08:00 window', () => {
+    const { config } = loadConfigResult(configPath);
+    assert.deepEqual(config.quietHours, { enabled: false, from: '22:00', to: '08:00' });
+  });
+
+  it('quietHours: a malformed time DISABLES the block rather than falling back to the default window', () => {
+    // The dangerous alternative: drop the bad "from", keep enabled:true, and
+    // silence every channel 22:00-08:00 because of a typo the user never saw.
+    fs.writeFileSync(configPath, JSON.stringify({
+      quietHours: { enabled: true, from: '25:00', to: '08:00' },
+    }), 'utf8');
+    const { config, problem } = loadConfigResult(configPath);
+    assert.equal(problem.type, 'validate');
+    assert.match(problem.message, /"quietHours\.from" must be a "HH:MM" 24-hour time, got "25:00" — quiet hours disabled/);
+    assert.equal(config.quietHours.enabled, false, 'the whole block degrades to disabled');
+    assert.equal(config.quietHours.from, '22:00', 'bad value reverted to default');
+  });
+
+  it('quietHours: a wrong-typed time disables the block too', () => {
+    fs.writeFileSync(configPath, JSON.stringify({
+      quietHours: { enabled: true, from: '22:00', to: 8 },
+    }), 'utf8');
+    const { config, problem } = loadConfigResult(configPath);
+    assert.match(problem.message, /"quietHours\.to" must be a "HH:MM" 24-hour time, got 8/);
+    assert.equal(config.quietHours.enabled, false);
+  });
+
+  it('quietHours: a wrong-typed enabled is reported AND reverted to the default', () => {
+    fs.writeFileSync(configPath, JSON.stringify({
+      quietHours: { enabled: 'yes', from: '22:00', to: '08:00' },
+    }), 'utf8');
+    const { config, problem } = loadConfigResult(configPath);
+    assert.match(problem.message, /"quietHours\.enabled" must be a boolean/);
+    assert.equal(config.quietHours.enabled, false);
+  });
+
+  it('quietHours: an unknown key is reported but kept', () => {
+    fs.writeFileSync(configPath, JSON.stringify({
+      quietHours: { enabled: true, from: '22:00', to: '08:00', channels: ['toast'] },
+    }), 'utf8');
+    const { config, problem } = loadConfigResult(configPath);
+    assert.match(problem.message, /unknown key "quietHours\.channels"/);
+    assert.equal(config.quietHours.enabled, true, 'a typo must not silently change behaviour');
+  });
+
   it('a fully valid user config produces no problem', () => {
     fs.writeFileSync(configPath, JSON.stringify({
       ntfy: { enabled: true, topic: 'aan-test' },

--- a/tests/suppress-hook.test.mjs
+++ b/tests/suppress-hook.test.mjs
@@ -1,0 +1,153 @@
+// tests/suppress-hook.test.mjs — proves suppression at the REAL hook entry
+// point: a snoozed (or quiet-hours) run sends nothing on any channel and emits
+// no claude terminalSequence, while still exiting 0 with a valid hook response.
+//
+// "Sends nothing" is proven, not assumed: ntfy and webhook both point at a real
+// local HTTP server (same no-mocking approach as ntfy-send.test.mjs), and every
+// case runs the identical event twice — once suppressed, once not — so a green
+// zero-requests assertion can never just mean "the wiring was broken".
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SCRUB = ['ANTHROPIC_API_KEY', 'GEMINI_API_KEY', 'OPENAI_API_KEY', 'CURSOR_API_KEY', 'NTFY_TOKEN'];
+const BELL_RESPONSE = { terminalSequence: '\x07' };
+const STOP_EVENT = JSON.stringify({ hook_event_name: 'Stop', cwd: '/work/app', session_id: 's' });
+
+// Two decimal-padded local wall-clock times, one hour either side of right now.
+// Deriving the window from the real clock (rather than hard-coding 22:00-08:00)
+// is what keeps this test from passing only at certain hours of the day; the
+// midnight-spanning arithmetic itself is covered exhaustively in suppress.test.mjs.
+function windowAroundNow() {
+  const now = new Date(); // ONE reading — two would risk straddling an hour boundary
+  const minute = String(now.getMinutes()).padStart(2, '0');
+  const pad = (h) => String((h + 24) % 24).padStart(2, '0');
+  return { from: `${pad(now.getHours() - 1)}:${minute}`, to: `${pad(now.getHours() + 1)}:${minute}` };
+}
+
+describe('notify.mjs suppression (real subprocess, real local HTTP server)', () => {
+  let server;
+  let base;
+  let received = [];
+
+  before(async () => {
+    await new Promise((resolve) => {
+      server = http.createServer((req, res) => {
+        let body = '';
+        req.on('data', (chunk) => { body += chunk; });
+        req.on('end', () => {
+          received.push({ url: req.url, body });
+          res.statusCode = 200;
+          res.end('ok');
+        });
+      });
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    base = `http://127.0.0.1:${server.address().port}`;
+  });
+  after(() => new Promise((resolve) => server.close(resolve)));
+  beforeEach(() => { received = []; });
+
+  // Toast is the one channel that cannot point at the local server, so it stays
+  // off — a real backend would fire a desktop notification on the test machine.
+  // ntfy + webhook + the claude bell are enough to prove the gate.
+  const configWith = (extra) => ({
+    toast: { enabled: false },
+    ntfy: { enabled: true, server: base, topic: 'snooze-test' },
+    webhook: { enabled: true, url: `${base}/hook`, format: 'generic' },
+    terminalBell: { enabled: true },
+    // Opted out so the un-suppressed control runs stay offline and their request
+    // count is exactly the event's own two — a real registry hit could otherwise
+    // add an update notice to the same local server the moment a newer anotifier
+    // is published.
+    updateCheck: { enabled: false },
+    ...extra,
+  });
+
+  // Runs the real hook against a throwaway HOME. `seed` gets the .anotifier dir
+  // so a case can drop a .snooze.json in next to the config.
+  function runHook(config, seed = () => {}) {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'aan-suppress-hook-'));
+    const cfgDir = path.join(home, '.anotifier');
+    fs.mkdirSync(cfgDir, { recursive: true });
+    fs.writeFileSync(path.join(cfgDir, 'config.json'), JSON.stringify(config));
+    seed(cfgDir);
+    const env = { ...process.env, HOME: home, USERPROFILE: home };
+    for (const k of SCRUB) delete env[k];
+
+    return new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, ['src/notify.mjs', '--source', 'claude'], { cwd: repoRoot, env });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (d) => { stdout += d; });
+      child.stderr.on('data', (d) => { stderr += d; });
+      child.on('error', reject);
+      child.on('close', (status) => {
+        fs.rmSync(home, { recursive: true, force: true });
+        resolve({ status, stdout, stderr });
+      });
+      child.stdin.end(STOP_EVENT);
+    });
+  }
+
+  const snoozeFor = (ms) => (cfgDir) =>
+    fs.writeFileSync(path.join(cfgDir, '.snooze.json'), JSON.stringify({ until: Date.now() + ms }));
+
+  it('CONTROL: an un-suppressed run really does send on every wired channel', async () => {
+    const res = await runHook(configWith());
+    assert.equal(res.status, 0, res.stderr);
+    assert.deepEqual(JSON.parse(res.stdout), BELL_RESPONSE, 'claude rings via terminalSequence');
+    assert.equal(received.length, 2, `expected ntfy + webhook, got ${JSON.stringify(received)}`);
+  });
+
+  it('a snoozed run sends on NO channel and emits no terminalSequence', async () => {
+    const res = await runHook(configWith(), snoozeFor(60 * 60 * 1000));
+    assert.equal(res.status, 0, res.stderr);
+    assert.equal(res.stdout, '{}\n', 'a snoozed claude run must not ring');
+    assert.equal(received.length, 0, `nothing may be sent while snoozed, got ${JSON.stringify(received)}`);
+  });
+
+  it('an EXPIRED snooze behaves exactly like no snooze', async () => {
+    const res = await runHook(configWith(), snoozeFor(-1000));
+    assert.equal(res.status, 0, res.stderr);
+    assert.deepEqual(JSON.parse(res.stdout), BELL_RESPONSE);
+    assert.equal(received.length, 2);
+  });
+
+  it('a corrupt snooze state file cannot silence the hook', async () => {
+    const res = await runHook(configWith(), (cfgDir) =>
+      fs.writeFileSync(path.join(cfgDir, '.snooze.json'), '{ not json ,,,'));
+    assert.equal(res.status, 0, res.stderr);
+    assert.deepEqual(JSON.parse(res.stdout), BELL_RESPONSE);
+    assert.equal(received.length, 2);
+  });
+
+  it('a run inside the quiet-hours window sends on NO channel and emits no terminalSequence', async () => {
+    const res = await runHook(configWith({ quietHours: { enabled: true, ...windowAroundNow() } }));
+    assert.equal(res.status, 0, res.stderr);
+    assert.equal(res.stdout, '{}\n');
+    assert.equal(received.length, 0, `nothing may be sent during quiet hours, got ${JSON.stringify(received)}`);
+  });
+
+  it('the same window with enabled: false (the default) suppresses nothing', async () => {
+    const res = await runHook(configWith({ quietHours: { enabled: false, ...windowAroundNow() } }));
+    assert.equal(res.status, 0, res.stderr);
+    assert.deepEqual(JSON.parse(res.stdout), BELL_RESPONSE);
+    assert.equal(received.length, 2);
+  });
+
+  it('a malformed quiet-hours time degrades to disabled instead of silencing the user', async () => {
+    // The validator drops `enabled` along with the bad time, so the run notifies
+    // normally — and the config problem is still recorded to errors.log.
+    const res = await runHook(configWith({ quietHours: { enabled: true, from: 'banana', to: '08:00' } }));
+    assert.equal(res.status, 0, res.stderr);
+    assert.deepEqual(JSON.parse(res.stdout), BELL_RESPONSE);
+    assert.equal(received.length, 2);
+  });
+});

--- a/tests/suppress.test.mjs
+++ b/tests/suppress.test.mjs
@@ -1,0 +1,243 @@
+// tests/suppress.test.mjs — the "stay silent" gate: snooze state + quiet hours.
+// The clock and the state path are both dependency-injected, and every
+// wall-clock time is built with the LOCAL-time Date constructor, so these pass
+// identically at 3am, in CI, and in any timezone.
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  parseDuration, formatClock,
+  readSnoozeUntil, writeSnoozeUntil, clearSnooze,
+  quietHoursWindow, inQuietHours, isSuppressed,
+} from '../src/suppress.mjs';
+
+// Local wall-clock time, timezone-independent by construction.
+const at = (hours, minutes = 0) => new Date(2026, 0, 15, hours, minutes, 0, 0);
+
+describe('parseDuration', () => {
+  it('accepts m / h / s units', () => {
+    assert.equal(parseDuration('30m'), 30 * 60 * 1000);
+    assert.equal(parseDuration('2h'), 2 * 60 * 60 * 1000);
+    assert.equal(parseDuration('90s'), 90 * 1000);
+  });
+
+  it('treats a bare number as minutes (the shape people type first)', () => {
+    assert.equal(parseDuration('45'), 45 * 60 * 1000);
+    assert.equal(parseDuration(45), 45 * 60 * 1000);
+  });
+
+  it('is forgiving about case and surrounding whitespace', () => {
+    assert.equal(parseDuration(' 2H '), 2 * 60 * 60 * 1000);
+  });
+
+  it('rejects garbage', () => {
+    for (const bad of ['banana', '', '  ', 'm', '30x', '1.5h', '30 m', '1h30m', null, undefined, {}]) {
+      assert.equal(parseDuration(bad), null, `${JSON.stringify(bad)} must not parse`);
+    }
+  });
+
+  it('rejects zero — a snooze that is already over is a typo, not a request', () => {
+    assert.equal(parseDuration('0'), null);
+    assert.equal(parseDuration('0m'), null);
+    assert.equal(parseDuration('0h'), null);
+  });
+
+  it('rejects negatives', () => {
+    assert.equal(parseDuration('-5'), null);
+    assert.equal(parseDuration('-5m'), null);
+  });
+});
+
+describe('formatClock', () => {
+  it('renders local HH:MM zero-padded', () => {
+    assert.equal(formatClock(at(9, 5).getTime()), '09:05');
+    assert.equal(formatClock(at(23, 59).getTime()), '23:59');
+    assert.equal(formatClock(at(0, 0).getTime()), '00:00');
+  });
+});
+
+describe('snooze state file', () => {
+  let dir, statePath;
+  const NOW = at(12, 0).getTime();
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'aan-snooze-'));
+    statePath = path.join(dir, '.snooze.json');
+  });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('no state file reads as not snoozed', () => {
+    assert.equal(readSnoozeUntil(statePath, NOW), null);
+  });
+
+  it('a future deadline reads as snoozed', () => {
+    writeSnoozeUntil(NOW + 60_000, statePath);
+    assert.equal(readSnoozeUntil(statePath, NOW), NOW + 60_000);
+  });
+
+  it('an EXPIRED deadline reads exactly like no snooze, and the dead file is dropped', () => {
+    writeSnoozeUntil(NOW - 1, statePath);
+    assert.equal(readSnoozeUntil(statePath, NOW), null);
+    assert.equal(fs.existsSync(statePath), false, 'expired state should be cleaned up opportunistically');
+  });
+
+  it('the deadline is exclusive at the exact millisecond it expires', () => {
+    writeSnoozeUntil(NOW, statePath);
+    assert.equal(readSnoozeUntil(statePath, NOW), null);
+  });
+
+  it('a corrupt state file reads as not snoozed (fail-open)', () => {
+    fs.writeFileSync(statePath, '{ not json ,,,');
+    assert.equal(readSnoozeUntil(statePath, NOW), null);
+  });
+
+  it('a state file holding a JSON scalar or the wrong type reads as not snoozed', () => {
+    for (const body of ['null', '7', '"soon"', '[]', '{"until":"later"}', '{}']) {
+      fs.writeFileSync(statePath, body);
+      assert.equal(readSnoozeUntil(statePath, NOW), null, body);
+    }
+  });
+
+  it('an unreadable state path never throws', () => {
+    // A DIRECTORY where the state file belongs: the read fails with something
+    // other than ENOENT, and the cleanup unlink fails too.
+    const blocked = path.join(dir, 'blocked.json');
+    fs.mkdirSync(blocked);
+    assert.equal(readSnoozeUntil(blocked, NOW), null);
+  });
+
+  it('writeSnoozeUntil creates the config dir if it does not exist yet', () => {
+    const nested = path.join(dir, 'fresh', '.snooze.json');
+    writeSnoozeUntil(NOW + 1000, nested);
+    assert.equal(readSnoozeUntil(nested, NOW), NOW + 1000);
+  });
+
+  it('clearSnooze removes an active snooze and reports that it did', () => {
+    writeSnoozeUntil(NOW + 60_000, statePath);
+    assert.equal(clearSnooze(statePath), true);
+    assert.equal(fs.existsSync(statePath), false);
+    assert.equal(readSnoozeUntil(statePath, NOW), null);
+  });
+
+  it('clearSnooze on a machine that was never snoozed reports false, not an error', () => {
+    assert.equal(clearSnooze(statePath), false);
+  });
+});
+
+describe('quietHoursWindow — when the feature is inert', () => {
+  it('null for a missing block or enabled: false (the default)', () => {
+    assert.equal(quietHoursWindow(undefined), null);
+    assert.equal(quietHoursWindow({ from: '22:00', to: '08:00' }), null);
+    assert.equal(quietHoursWindow({ enabled: false, from: '22:00', to: '08:00' }), null);
+  });
+
+  it('null when from === to — a zero-length window is OFF, never all-day', () => {
+    assert.equal(quietHoursWindow({ enabled: true, from: '09:00', to: '09:00' }), null);
+  });
+
+  it('null for a malformed time — degrades to disabled rather than guessing', () => {
+    for (const bad of ['banana', '25:00', '22:60', '2200', '22:0', '', 8, null]) {
+      assert.equal(quietHoursWindow({ enabled: true, from: bad, to: '08:00' }), null, JSON.stringify(bad));
+      assert.equal(quietHoursWindow({ enabled: true, from: '22:00', to: bad }), null, JSON.stringify(bad));
+    }
+  });
+
+  it('returns the parsed window for a usable block', () => {
+    assert.deepEqual(quietHoursWindow({ enabled: true, from: '22:00', to: '08:00' }), {
+      from: '22:00', to: '08:00', fromMin: 1320, toMin: 480,
+    });
+  });
+});
+
+describe('inQuietHours — window containment', () => {
+  const overnight = { enabled: true, from: '22:00', to: '08:00' };
+  const daytime = { enabled: true, from: '08:00', to: '22:00' };
+
+  it('a midnight-spanning window covers BOTH sides of midnight', () => {
+    assert.equal(inQuietHours(overnight, at(22, 0)), true, 'start of the evening leg');
+    assert.equal(inQuietHours(overnight, at(23, 59)), true, 'end of the evening leg');
+    assert.equal(inQuietHours(overnight, at(0, 0)), true, 'midnight itself');
+    assert.equal(inQuietHours(overnight, at(3, 30)), true, 'the small hours');
+    assert.equal(inQuietHours(overnight, at(7, 59)), true, 'end of the morning leg');
+  });
+
+  it('a midnight-spanning window leaves the day alone', () => {
+    assert.equal(inQuietHours(overnight, at(8, 0)), false, 'end is exclusive');
+    assert.equal(inQuietHours(overnight, at(12, 0)), false);
+    assert.equal(inQuietHours(overnight, at(21, 59)), false, 'start is inclusive, one minute early is not');
+  });
+
+  it('a same-day window (08:00-22:00, no midnight span) works too', () => {
+    assert.equal(inQuietHours(daytime, at(8, 0)), true, 'start inclusive');
+    assert.equal(inQuietHours(daytime, at(15, 0)), true);
+    assert.equal(inQuietHours(daytime, at(21, 59)), true);
+    assert.equal(inQuietHours(daytime, at(22, 0)), false, 'end exclusive');
+    assert.equal(inQuietHours(daytime, at(7, 59)), false);
+    assert.equal(inQuietHours(daytime, at(23, 0)), false);
+  });
+
+  it('a one-minute window is honored exactly', () => {
+    const sliver = { enabled: true, from: '13:00', to: '13:01' };
+    assert.equal(inQuietHours(sliver, at(12, 59)), false);
+    assert.equal(inQuietHours(sliver, at(13, 0)), true);
+    assert.equal(inQuietHours(sliver, at(13, 1)), false);
+  });
+
+  it('an inert block is never inside the window, at any hour', () => {
+    for (let h = 0; h < 24; h++) {
+      assert.equal(inQuietHours({ enabled: false, from: '22:00', to: '08:00' }, at(h)), false);
+      assert.equal(inQuietHours({ enabled: true, from: '09:00', to: '09:00' }, at(h)), false);
+      assert.equal(inQuietHours({ enabled: true, from: 'banana', to: '08:00' }, at(h)), false);
+      assert.equal(inQuietHours(undefined, at(h)), false);
+    }
+  });
+});
+
+describe('isSuppressed — the single gate the hook path asks', () => {
+  let dir, statePath;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'aan-suppress-'));
+    statePath = path.join(dir, '.snooze.json');
+  });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  const noon = at(12, 0).getTime();
+  const night = at(23, 0).getTime();
+  const overnight = { quietHours: { enabled: true, from: '22:00', to: '08:00' } };
+
+  it('null when nothing is asking for quiet', () => {
+    assert.equal(isSuppressed({}, { statePath, now: noon }), null);
+    assert.equal(isSuppressed(overnight, { statePath, now: noon }), null);
+  });
+
+  it('an active snooze suppresses on its own, outside any quiet window', () => {
+    writeSnoozeUntil(noon + 60_000, statePath);
+    assert.deepEqual(isSuppressed({}, { statePath, now: noon }), { reason: 'snooze', until: noon + 60_000 });
+  });
+
+  it('an expired snooze does not suppress', () => {
+    writeSnoozeUntil(noon - 1, statePath);
+    assert.equal(isSuppressed({}, { statePath, now: noon }), null);
+  });
+
+  it('a corrupt state file does not suppress', () => {
+    fs.writeFileSync(statePath, 'not json at all');
+    assert.equal(isSuppressed({}, { statePath, now: noon }), null);
+  });
+
+  it('quiet hours suppresses on its own, with no snooze in sight', () => {
+    assert.deepEqual(isSuppressed(overnight, { statePath, now: night }), {
+      reason: 'quietHours', from: '22:00', to: '08:00',
+    });
+  });
+
+  it('either source alone is enough — and both at once still suppresses', () => {
+    writeSnoozeUntil(night + 60_000, statePath);
+    assert.equal(isSuppressed(overnight, { statePath, now: night }).reason, 'snooze');
+  });
+
+  it('a missing config never throws (defaults are absent on a fresh install)', () => {
+    assert.equal(isSuppressed(undefined, { statePath, now: noon }), null);
+  });
+});

--- a/tests/update-banner.test.mjs
+++ b/tests/update-banner.test.mjs
@@ -1,0 +1,70 @@
+// tests/update-banner.test.mjs — regression for the stale "v1.3.0 → v1.3.0"
+// banner. Both CLI call sites used to print whatever version the shared
+// .update-check.json cache held, so for up to the 24h TTL after an upgrade they
+// nagged you to install the version you had just installed. The semver gate is
+// now re-asserted at both sites, exactly as the hook path already did.
+//
+// Every case seeds a FRESH cache, so the CLI is served entirely from disk and
+// these run offline.
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const pkg = require('../package.json');
+
+// Runs the real CLI with a throwaway HOME whose update cache claims `latest`.
+function runCli(args, latest) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'aan-banner-'));
+  const cfgDir = path.join(home, '.anotifier');
+  fs.mkdirSync(cfgDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(cfgDir, '.update-check.json'),
+    JSON.stringify({ checkedAt: Date.now(), latest }), // fresh: no network
+  );
+  const res = spawnSync(process.execPath, ['cli/index.mjs', ...args], {
+    cwd: repoRoot,
+    env: { ...process.env, HOME: home, USERPROFILE: home },
+    encoding: 'utf8',
+    timeout: 30000,
+  });
+  fs.rmSync(home, { recursive: true, force: true });
+  return { status: res.status, stdout: res.stdout || '', stderr: res.stderr || '' };
+}
+
+// `--version` exercises cli/index.mjs's banner; `status` prints its own copy and
+// suppresses index's, so it exercises the second call site.
+for (const [label, args] of [['--version', ['--version']], ['status', ['status']]]) {
+  describe(`update banner via \`anotifier ${label}\``, () => {
+    it('stays quiet when the cached version is the one already installed', () => {
+      const res = runCli(args, pkg.version);
+      assert.equal(res.status, 0, res.stderr);
+      assert.ok(!res.stdout.includes('Update available'), `banner must not fire for v${pkg.version}: ${res.stdout}`);
+    });
+
+    it('stays quiet when the cached version is OLDER than the installed one', () => {
+      const res = runCli(args, '0.0.1');
+      assert.equal(res.status, 0, res.stderr);
+      assert.ok(!res.stdout.includes('Update available'), `never nag a downgrade: ${res.stdout}`);
+    });
+
+    it('still fires for a genuinely newer version', () => {
+      const res = runCli(args, '99.0.0');
+      assert.equal(res.status, 0, res.stderr);
+      assert.ok(res.stdout.includes('Update available'), `banner should fire: ${res.stdout}`);
+      assert.ok(res.stdout.includes('99.0.0'), res.stdout);
+    });
+
+    it('stays quiet when the cache holds no version at all', () => {
+      const res = runCli(args, null);
+      assert.equal(res.status, 0, res.stderr);
+      assert.ok(!res.stdout.includes('Update available'), res.stdout);
+    });
+  });
+}


### PR DESCRIPTION
## What

Three daily-driver comfort features:

1. **`anotifier snooze <duration>`** — `30m` / `2h` / `90s` / bare minutes (`45`). `snooze off` cancels, bare `snooze` reports state. Writes a deadline to `~/.anotifier/.snooze.json` (same dotfile convention as the update-check cache). Strict CLI: `banana`, `0`, `-5` exit 1 and write nothing. Also exposed as a plugin slash command (`commands/snooze.md`), matching every other user-facing command.
2. **Quiet hours** — `quietHours: { enabled: false, from: "22:00", to: "08:00" }` (default OFF), local machine time, start-inclusive / end-exclusive, midnight-spanning windows supported. `from === to` is treated as OFF, not a 24h window.
3. **Stale banner fix** — both CLI banner call sites (`cli/index.mjs`, `cli/status.mjs`) now re-assert `isNewer`, so the banner can no longer show `v1.3.0 → v1.3.0` for up to 24h after an upgrade.

## How

One gate (`src/suppress.mjs` → `isSuppressed`), checked in the hook after config load and **before** the dedup lock and routing. Either source alone silences ALL four channels together — a suppressed claude run emits exactly `{}` with **no** `terminalSequence`, exits 0, and skips the update-check entirely (no network, no state write; it runs on the next un-silenced run). Everything on the read path is fail-open: a corrupt/expired/unreadable snooze file reads as not-snoozed and is opportunistically cleaned up — a broken file can never silence the notifier forever.

One deliberate deviation from the validator's sibling-block convention: an unusable `quietHours.from`/`to` drops `enabled` too (landing on the default `false`) instead of falling back to the default window — silencing someone 22:00–08:00 because of a typo they never saw is the worst failure mode this config has. The ordering of that pass before `checkBlock` is load-bearing and commented.

Per-channel scoping was considered and **skipped**: two suppression sources with different granularity leaves no honest answer for the update notice. Snoozed means silent, period. (A `quietHours.channels` key today is reported-but-kept as unknown; there's a test pinning that.)

`anotifier status` gains Snooze and Quiet hours rows. README documents all three features.

## Tests

+63 across 5 files: duration parsing, snooze lifecycle (active/expired/corrupt/off), window containment incl. midnight span and `from===to`, validator degradation, banner regression at both call sites, and a hook-level A/B against a real local HTTP server (control case first, so the zero-request assertions can't pass vacuously). Anti-vacuity verified by stashing the banner fix — 4 of 8 cases fail without it.

Suite: **406 tests, 398 pass, 0 fail, 0 cancelled, 8 platform-gated skips** — verified on node 24.18.0, 22.23.1, and 20.20.2 (zero cancellations: the node<=22 event-loop drain from #16 does not apply; no test injects never-settling promises).