### PR TITLE
fix: suppress task_complete while background subagents still run

### DIFF
--- a/src/notify.mjs
+++ b/src/notify.mjs
@@ -130,6 +130,24 @@ async function main() {
       process.exit(0);
     }
 
+    // A claude Stop can fire while the turn's background subagents and shells are
+    // still grinding — Claude Code's own background_tasks ledger says so. Pinging
+    // "Task complete" at that moment is simply wrong, so leave exactly like the
+    // suppression gate above: plain '{}\n', no channel, no terminalSequence. And
+    // like it, BEFORE the dedup lock — a held-back run should do the least work
+    // and must not burn the lock the real completion will need. This is expected
+    // behavior, not a fault, so nothing goes to errors.log (unlike the unmapped
+    // event below). Self-correcting by design: when the work drains, Claude Code
+    // re-invokes the agent and its final Stop carries an empty ledger, which
+    // notifies for real — no timers or bookkeeping on our side. Claude-only:
+    // codex/gemini send no such field, and cursor's subagentStop -> task_complete
+    // is per-subagent by design, so neither may be gated on it.
+    if (event.source === 'claude' && event.event === 'task_complete' && event.hasLiveBackgroundWork) {
+      await flushErrorReporting();
+      process.stdout.write('{}\n');
+      process.exit(0);
+    }
+
     // Deduplicate AFTER parsing so the lock can key on source+event+session
     if (!acquireNotifyLock(dedupKey(event))) {
       await flushErrorReporting();

--- a/src/parse-input.mjs
+++ b/src/parse-input.mjs
@@ -23,6 +23,24 @@ const EVENT_MAP = {
   },
 };
 
+// Claude Code's Stop payload carries `background_tasks`: the ledger of subagents
+// and background shells still running past the main agent's turn ([] when the
+// turn really is done, ABSENT on older Claude Code). An entry counts as LIVE
+// unless it explicitly says otherwise — only a string status that isn't
+// 'running' (e.g. 'completed', 'failed') settles it, so an unrecognized shape
+// fails toward "still live". The two errors are not symmetric: a premature
+// "Task complete" ping actively misleads, while a suppressed one self-corrects
+// when the work drains and Claude re-invokes the agent for a final Stop.
+// Absent / non-list => false, which keeps older Claude Code (and every other
+// tool, none of which send this) on exactly today's behavior.
+function detectLiveBackgroundWork(raw) {
+  if (!Array.isArray(raw.background_tasks)) return false;
+  return raw.background_tasks.some(
+    (task) => task !== null && typeof task === 'object'
+      && (typeof task.status !== 'string' || task.status === 'running'),
+  );
+}
+
 export function parseInput(raw, source, eventOverride) {
   // --event CLI arg takes priority (used by Codex/Cursor which don't send hook_event_name on stdin).
   // Claude and Gemini include hook_event_name in stdin JSON.
@@ -42,6 +60,10 @@ export function parseInput(raw, source, eventOverride) {
     // structured payload can never smuggle newlines/objects downstream.
     transcriptPath: raw.transcript_path || '',
     message: typeof raw.message === 'string' ? raw.message : '',
+    // True when this Stop fired with work still pending behind it — notify.mjs
+    // holds the "Task complete" ping back rather than announcing a turn that
+    // isn't over. See detectLiveBackgroundWork above.
+    hasLiveBackgroundWork: detectLiveBackgroundWork(raw),
     // Kept even when unmapped: the hook logs unrecognized events by this name
     // so misconfigured wiring (or a tool's new event type) is visible in
     // errors.log instead of vanishing.

--- a/tests/notify-background-tasks.test.mjs
+++ b/tests/notify-background-tasks.test.mjs
@@ -1,0 +1,192 @@
+// tests/notify-background-tasks.test.mjs — proves the background-work gate at
+// the REAL hook entry point: a claude Stop that fires while its subagents /
+// background shells are still running notifies on NO channel, while the same
+// Stop with a drained ledger notifies normally.
+//
+// "Sends nothing" is proven, not assumed: ntfy and webhook both point at a real
+// local HTTP server (same no-mocking approach as suppress-hook.test.mjs), and
+// every held-back case is paired with a control run that differs only in the
+// ledger — so a green zero-requests assertion can never just mean "the wiring
+// was broken".
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SCRUB = ['ANTHROPIC_API_KEY', 'GEMINI_API_KEY', 'OPENAI_API_KEY', 'CURSOR_API_KEY', 'NTFY_TOKEN'];
+const BELL_RESPONSE = { terminalSequence: '\x07' };
+
+const RUNNING_SUBAGENT = {
+  id: 'bg-1', type: 'subagent', status: 'running',
+  description: 'sweep the platform backends', agent_type: 'Explore',
+};
+
+describe('notify.mjs background-work gate (real subprocess, real local HTTP server)', () => {
+  let server;
+  let base;
+  let received = [];
+
+  before(async () => {
+    await new Promise((resolve) => {
+      server = http.createServer((req, res) => {
+        let body = '';
+        req.on('data', (chunk) => { body += chunk; });
+        req.on('end', () => {
+          received.push({ url: req.url, body });
+          res.statusCode = 200;
+          res.end('ok');
+        });
+      });
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    base = `http://127.0.0.1:${server.address().port}`;
+  });
+  after(() => new Promise((resolve) => server.close(resolve)));
+  beforeEach(() => { received = []; });
+
+  // Toast is the one channel that cannot point at the local server, so it stays
+  // off — a real backend would fire a desktop notification on the test machine.
+  // ntfy + webhook + the claude bell are enough to prove the gate.
+  // updateCheck is opted out so the control runs stay offline and their request
+  // count is exactly the event's own two.
+  const config = () => ({
+    toast: { enabled: false },
+    ntfy: { enabled: true, server: base, topic: 'bg-test' },
+    webhook: { enabled: true, url: `${base}/hook`, format: 'generic' },
+    terminalBell: { enabled: true },
+    updateCheck: { enabled: false },
+  });
+
+  // A throwaway HOME the caller owns and removes — kept alive after the run so a
+  // case can read back errors.log or check for a dedup lock file.
+  function makeHome() {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'aan-bgwork-'));
+    const cfgDir = path.join(home, '.anotifier');
+    fs.mkdirSync(cfgDir, { recursive: true });
+    fs.writeFileSync(path.join(cfgDir, 'config.json'), JSON.stringify(config()));
+    return home;
+  }
+
+  // Async spawn, never spawnSync: the local server runs on THIS process's event
+  // loop, so a blocking child would never get its ntfy/webhook connection
+  // accepted and every control run would read as "sent nothing".
+  function runHook(home, payload, source = 'claude') {
+    const env = { ...process.env, HOME: home, USERPROFILE: home };
+    for (const k of SCRUB) delete env[k];
+    return new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, ['src/notify.mjs', '--source', source], { cwd: repoRoot, env });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (d) => { stdout += d; });
+      child.stderr.on('data', (d) => { stderr += d; });
+      child.on('error', reject);
+      child.on('close', (status) => resolve({ status, stdout, stderr }));
+      child.stdin.end(JSON.stringify(payload));
+    });
+  }
+
+  // Each case gets a fresh session id: the dedup lock keys on it, so reusing one
+  // across cases would silence a later run for the wrong reason.
+  const stop = (sessionId, extra = {}) =>
+    ({ hook_event_name: 'Stop', cwd: '/work/app', session_id: sessionId, ...extra });
+
+  it('CONTROL: a Stop with a drained ledger notifies on every wired channel', async () => {
+    const home = makeHome();
+    const res = await runHook(home, stop('drained', { background_tasks: [] }));
+    fs.rmSync(home, { recursive: true, force: true });
+    assert.equal(res.status, 0, res.stderr);
+    assert.deepEqual(JSON.parse(res.stdout), BELL_RESPONSE, 'claude rings via terminalSequence');
+    assert.equal(received.length, 2, `expected ntfy + webhook, got ${JSON.stringify(received)}`);
+  });
+
+  it('a Stop with a running subagent notifies on NO channel and emits no terminalSequence', async () => {
+    const home = makeHome();
+    const res = await runHook(home, stop('livesub', { background_tasks: [RUNNING_SUBAGENT] }));
+    fs.rmSync(home, { recursive: true, force: true });
+    assert.equal(res.status, 0, res.stderr);
+    assert.equal(res.stdout, '{}\n', 'a premature Task complete must not ring');
+    assert.equal(received.length, 0, `nothing may be sent while work is live, got ${JSON.stringify(received)}`);
+  });
+
+  it('a Stop with a running background shell is held back the same way', async () => {
+    const home = makeHome();
+    const res = await runHook(home, stop('liveshell', {
+      background_tasks: [{ id: 'bg-2', type: 'shell', status: 'running', command: 'npm run build' }],
+    }));
+    fs.rmSync(home, { recursive: true, force: true });
+    assert.equal(res.status, 0, res.stderr);
+    assert.equal(res.stdout, '{}\n');
+    assert.equal(received.length, 0, `nothing may be sent while work is live, got ${JSON.stringify(received)}`);
+  });
+
+  it('holding the ping back writes NOTHING to errors.log — it is expected, not a fault', async () => {
+    // Unlike the unmapped-event exit (which logs a router entry by design), a
+    // held-back Stop is normal operation and must leave `status` clean.
+    const home = makeHome();
+    const res = await runHook(home, stop('nolog', { background_tasks: [RUNNING_SUBAGENT] }));
+    const logPath = path.join(home, '.anotifier', 'errors.log');
+    const log = fs.existsSync(logPath) ? fs.readFileSync(logPath, 'utf8') : '';
+    fs.rmSync(home, { recursive: true, force: true });
+    assert.equal(res.status, 0, res.stderr);
+    assert.equal(res.stdout, '{}\n');
+    assert.equal(log, '', `a held-back Stop must not be logged as an error, got: ${log}`);
+  });
+
+  it('a held-back Stop burns no dedup lock, so the real completion still notifies', async () => {
+    // The gate sits BEFORE acquireNotifyLock precisely so this holds: both runs
+    // share a HOME and a session id, which means one dedup key — if the
+    // held-back run had taken the lock, the real completion would be swallowed.
+    const home = makeHome();
+    const held = await runHook(home, stop('samekey', { background_tasks: [RUNNING_SUBAGENT] }));
+    assert.equal(held.status, 0, held.stderr);
+    assert.equal(held.stdout, '{}\n');
+    assert.equal(received.length, 0);
+
+    // Deterministic half: no lock file exists for this event at all.
+    const lockFile = path.join(home, '.anotifier', '.lock-claude-task_complete-samekey');
+    assert.equal(fs.existsSync(lockFile), false, 'the held-back run must not create a dedup lock');
+
+    // Behavioral half: the drained Stop that follows really does get through.
+    const real = await runHook(home, stop('samekey', { background_tasks: [] }));
+    fs.rmSync(home, { recursive: true, force: true });
+    assert.equal(real.status, 0, real.stderr);
+    assert.deepEqual(JSON.parse(real.stdout), BELL_RESPONSE);
+    assert.equal(received.length, 2, `the real completion must notify, got ${JSON.stringify(received)}`);
+  });
+
+  it('a Stop with no background_tasks field at all notifies (older Claude Code)', async () => {
+    const home = makeHome();
+    const res = await runHook(home, stop('absent'));
+    fs.rmSync(home, { recursive: true, force: true });
+    assert.equal(res.status, 0, res.stderr);
+    assert.deepEqual(JSON.parse(res.stdout), BELL_RESPONSE);
+    assert.equal(received.length, 2);
+  });
+
+  it('a ledger whose entries all report a settled status notifies', async () => {
+    const home = makeHome();
+    const res = await runHook(home, stop('settled', {
+      background_tasks: [{ id: 'bg-3', type: 'subagent', status: 'completed' }],
+    }));
+    fs.rmSync(home, { recursive: true, force: true });
+    assert.equal(res.status, 0, res.stderr);
+    assert.deepEqual(JSON.parse(res.stdout), BELL_RESPONSE);
+    assert.equal(received.length, 2);
+  });
+
+  it('the gate is claude-only: a codex Stop carrying the same ledger still notifies', async () => {
+    // Codex never sends background_tasks, and cursor's per-subagent
+    // subagentStop -> task_complete is deliberate — neither may be gated on it.
+    const home = makeHome();
+    const res = await runHook(home, { hook_event_name: 'Stop', cwd: '/work/app', session_id: 'cdx', background_tasks: [RUNNING_SUBAGENT] }, 'codex');
+    fs.rmSync(home, { recursive: true, force: true });
+    assert.equal(res.status, 0, res.stderr);
+    assert.equal(res.stdout, '{}\n', 'codex rings via bell.mjs, never terminalSequence');
+    assert.equal(received.length, 2, `codex must still notify, got ${JSON.stringify(received)}`);
+  });
+});

--- a/tests/parse-input.test.mjs
+++ b/tests/parse-input.test.mjs
@@ -122,3 +122,78 @@ describe('parseInput', () => {
     assert.equal(result.event, 'unknown');
   });
 });
+
+describe('parseInput background_tasks ledger (hasLiveBackgroundWork)', () => {
+  // Claude Code's Stop payload lists the subagents / background shells still
+  // running behind the main agent's turn. notify.mjs holds the "Task complete"
+  // ping back while any of them is live; the deciding rule is that only an
+  // explicit non-'running' string status settles an entry, so anything
+  // unrecognized stays live (a premature ping misleads, a held-back one
+  // self-corrects on the final Stop).
+  const stopWith = (background_tasks) =>
+    parseInput({ session_id: 's', cwd: '/work/app', hook_event_name: 'Stop', background_tasks }, 'claude');
+
+  it('is true for a running subagent entry', () => {
+    const result = stopWith([
+      { id: 'bg1', type: 'subagent', status: 'running', description: 'audit the config loader', agent_type: 'Explore' },
+    ]);
+    assert.equal(result.event, 'task_complete');
+    assert.equal(result.hasLiveBackgroundWork, true);
+  });
+
+  it('is true for a running background shell entry', () => {
+    const result = stopWith([{ id: 'bg2', type: 'shell', status: 'running', command: 'npm run build' }]);
+    assert.equal(result.hasLiveBackgroundWork, true);
+  });
+
+  it('is true when status is missing entirely', () => {
+    assert.equal(stopWith([{ id: 'bg3', type: 'subagent' }]).hasLiveBackgroundWork, true);
+  });
+
+  it('is true when status is present but not a string', () => {
+    // Only an explicit non-'running' STRING settles an entry — a future payload
+    // shape must never read as "done" by accident.
+    assert.equal(stopWith([{ id: 'bg4', status: { state: 'running' } }]).hasLiveBackgroundWork, true);
+    assert.equal(stopWith([{ id: 'bg5', status: null }]).hasLiveBackgroundWork, true);
+  });
+
+  it('is false for an empty ledger — the turn really is over', () => {
+    assert.equal(stopWith([]).hasLiveBackgroundWork, false);
+  });
+
+  it('is false when the field is absent (older Claude Code keeps today behavior)', () => {
+    const result = parseInput({ session_id: 's', cwd: '/work/app', hook_event_name: 'Stop' }, 'claude');
+    assert.equal(result.hasLiveBackgroundWork, false);
+  });
+
+  it('is false when the field is not a list', () => {
+    assert.equal(stopWith('running').hasLiveBackgroundWork, false);
+    assert.equal(stopWith({ bg1: { status: 'running' } }).hasLiveBackgroundWork, false);
+    assert.equal(stopWith(null).hasLiveBackgroundWork, false);
+  });
+
+  it('is false when every entry carries an explicit non-running status', () => {
+    const result = stopWith([
+      { id: 'bg6', type: 'subagent', status: 'completed' },
+      { id: 'bg7', type: 'shell', status: 'failed' },
+    ]);
+    assert.equal(result.hasLiveBackgroundWork, false);
+  });
+
+  it('is true when one live entry sits beside non-object junk', () => {
+    // Junk entries are not live on their own, but they must not mask a real one.
+    const result = stopWith([null, 'bg8', 42, { id: 'bg9', type: 'shell', status: 'running' }]);
+    assert.equal(result.hasLiveBackgroundWork, true);
+  });
+
+  it('is false for a ledger of nothing but non-object junk', () => {
+    assert.equal(stopWith([null, 'bg10', 42]).hasLiveBackgroundWork, false);
+  });
+
+  it('is reported for other sources too, but stays false since they never send it', () => {
+    // notify.mjs gates on source === 'claude' anyway; this pins that a codex or
+    // cursor event can never arrive carrying a surprise true.
+    assert.equal(parseInput({ session_id: 'c', hook_event_name: 'Stop' }, 'codex').hasLiveBackgroundWork, false);
+    assert.equal(parseInput({ session_id: 'cu' }, 'cursor', 'subagentStop').hasLiveBackgroundWork, false);
+  });
+});


### PR DESCRIPTION
## What

Hold the "Task complete" notification back while Claude Code's `Stop` payload still lists running background work. The final `Stop` — the one whose ledger is drained — delivers the real ping.

## Why

`Stop → task_complete` fired the moment the MAIN agent's turn ended. A turn that just dispatched background subagents (or long background shell tasks) ends within seconds, so users got a "Task complete" toast/phone push while the actual work had minutes left to run.

## How (empirically grounded)

Probed against the real `claude` CLI (Aug 2026): the `Stop` payload carries `background_tasks` — Claude Code's own pending-work ledger, listing `{"type": "subagent", "status": "running", ...}` and `{"type": "shell", "status": "running", ...}` entries, `[]` when the turn really is done, absent on older versions. And when background work drains, Claude Code re-invokes the agent, whose final `Stop` carries an empty ledger — so suppression is self-correcting, no timers or bookkeeping.

- `parseInput` gains `hasLiveBackgroundWork`: an entry counts as live unless its `status` is an explicit non-`"running"` string — unknown shapes fail toward "still live" (a premature ping misleads; a held-back one self-corrects). Absent / non-list → false, so older Claude Code and every other tool keep today's behavior byte-for-byte.
- `notify.mjs` exits with the plain `'{}\n'` (no channels, no terminalSequence, no errors.log entry — this is expected behavior, not a fault) BEFORE the dedup lock, so the held-back run consumes nothing the real completion will need. Claude-only: codex/gemini send no such field; cursor's `subagentStop → task_complete` is per-subagent by design.

## Tests

11 new `parseInput` unit pins + a new real-subprocess suite (`tests/notify-background-tasks.test.mjs`, modeled on suppress-hook.test.mjs with a real local HTTP server): a live ledger sends on ZERO channels with empty errors.log and no dedup lock file; a following drained Stop with the same session id still notifies; a codex Stop carrying the identical ledger still notifies. Each held-back case is paired with a control differing only in the ledger.

`npm test`: 425 tests, 417 pass, 0 fail (8 pre-existing platform-gated skips).
