### PR TITLE
fix: idle "waiting for your input" nag pings at default priority, not urgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,18 @@ Controlled per channel:
 | `needs_input` | Reminder | urgent | Agent needs your input or permission |
 | `session_start` | Default | low | New session started (all channels off by default) |
 
+**Claude's idle reminder is quieter than a real prompt.** About a minute after a turn ends, Claude Code sends a second notification along the lines of *"Claude is waiting for your input"*. Nothing is blocked -- the work is done -- so anotifier delivers that one at `default` priority with a calm tag instead of the urgent `needs_input` treatment. A genuine permission prompt is untouched and still arrives urgent. The reminder is never suppressed, only turned down, and if Claude ever changes that wording the reminder simply goes back to being urgent -- it can never go silent. To pick your own level for it, set `idleReminderPriority` on the event:
+
+```json
+{
+  "events": {
+    "needs_input": { "idleReminderPriority": "low" }
+  }
+}
+```
+
+It takes the same `min` / `low` / `default` / `high` / `urgent` scale as `priority`, and applies only to the idle reminder.
+
 ### Error visibility
 
 Hook and channel errors never interrupt your agent -- they're appended to `~/.anotifier/errors.log` and surfaced by `npx anotifier status`, so a misconfigured toast backend or unreachable ntfy topic shows up as a logged error instead of a silent no-op. Set `sentry.enabled` to `true` (with a `sentry.dsn`) to also mirror those errors to [Sentry](https://sentry.io) through a built-in, zero-dependency envelope client: no SDK is bundled, no telemetry is collected, and nothing leaves your machine unless you opt in -- only error data is sent.

--- a/src/config-loader.mjs
+++ b/src/config-loader.mjs
@@ -33,6 +33,11 @@ export function getConfigPath() {
 const EVENT_OVERRIDE_TYPES = {
   toastSound: 'string',
   priority: 'string',
+  // Opt-in override for the priority of Claude's idle "waiting for your input"
+  // nag, which src/router.mjs delivers at 'default' instead of the urgent
+  // needs_input value. Absent on purpose from default-config.json: only an
+  // explicit user value beats the downgrade.
+  idleReminderPriority: 'string',
   ntfyTags: 'string',
   toastEnabled: 'boolean',
   ntfyEnabled: 'boolean',
@@ -44,6 +49,9 @@ const RENAMED_KEYS = {
   ntfyPriority: 'priority',
 };
 const PRIORITY_VALUES = ['min', 'low', 'default', 'high', 'urgent'];
+// Every event override validated against the ntfy 5-level scale. One list, so a
+// new priority-shaped key can never quietly skip the enum check.
+const PRIORITY_KEYS = ['priority', 'idleReminderPriority'];
 const FORMAT_VALUES = ['generic', 'slack', 'discord', 'telegram'];
 
 // "HH:MM" on a 24-hour clock → minutes since midnight, or null when unusable.
@@ -140,8 +148,8 @@ function validateUserConfig(user) {
           if (typeof val !== expected) {
             issues.push(`"events.${eventName}.${key}" must be a ${expected}, got ${typeof val}`);
             delete overrides[key];
-          } else if (key === 'priority' && !PRIORITY_VALUES.includes(val)) {
-            issues.push(`"events.${eventName}.priority" must be one of ${PRIORITY_VALUES.join('|')}, got "${val}"`);
+          } else if (PRIORITY_KEYS.includes(key) && !PRIORITY_VALUES.includes(val)) {
+            issues.push(`"events.${eventName}.${key}" must be one of ${PRIORITY_VALUES.join('|')}, got "${val}"`);
             delete overrides[key];
           }
         }

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -4,6 +4,32 @@ const EVENT_MESSAGES = {
   session_start: 'Session started',
 };
 
+// Claude Code fires a second Notification ~60s after a turn ends, whose text
+// ("Claude is waiting for your input") is an idle nag, not a request: nobody is
+// blocked, the work is done. Routed as a plain needs_input it earns the urgent
+// priority + alarm tags that exist for a REAL permission prompt, so every task
+// the user walks away from ends in the loudest ping the product can send.
+//
+// Detection is a substring match on Claude's own copy, deliberately: if that
+// copy ever changes, the match fails and the nag stays URGENT. The failure
+// direction is the whole design — a nag that is too loud is an annoyance, a
+// permission prompt that went quiet is a stalled agent, so drift must fail
+// toward loud. A real prompt never carries this text and is untouched.
+//
+// Parity note: magent's state hook filters the identical substring, but acts
+// differently — it DROPS the event, because a finished session flipping to
+// needs-input is a lie in a persistent status table. A one-shot ping is a
+// defensible nudge, so anotifier only turns the volume down.
+const IDLE_REMINDER_TEXT = 'waiting for your input';
+const IDLE_REMINDER_TAGS = 'hourglass_flowing_sand';
+
+function isIdleReminder(event) {
+  return event.source === 'claude'
+    && event.event === 'needs_input'
+    && typeof event.message === 'string'
+    && event.message.toLowerCase().includes(IDLE_REMINDER_TEXT);
+}
+
 // Build the canonical notification object every channel consumes.
 // `priority` uses the ntfy 5-level scale (min|low|default|high|urgent) as the
 // app-wide scale: ntfy sends it verbatim, the Linux backend maps it to
@@ -17,12 +43,20 @@ export function route(event, config) {
   const label = sourceConfig.label || event.source;
   const prefix = event.projectName ? `${event.projectName}: ` : '';
 
+  // Volume only: the idle nag keeps its channels, title and rich body (the nag
+  // text is still the ntfy body via transcript.mjs) — it just stops shouting.
+  // `events.needs_input.idleReminderPriority` is the escape hatch for users who
+  // want the nag louder (or silent-adjacent at 'min'); absent means 'default'.
+  const idleReminder = isIdleReminder(event);
+
   return {
     title: label,
     message: `${prefix}${messageTemplate}`,
     toastSound: eventConfig.toastSound || 'Default',
-    priority: eventConfig.priority || 'default',
-    ntfyTags: eventConfig.ntfyTags || '',
+    priority: idleReminder
+      ? (eventConfig.idleReminderPriority || 'default')
+      : (eventConfig.priority || 'default'),
+    ntfyTags: idleReminder ? IDLE_REMINDER_TAGS : (eventConfig.ntfyTags || ''),
     icon: sourceConfig.icon || '',
     clickToFocus: config.toast?.clickToFocus !== false,
     event: event.event,

--- a/tests/config-loader-validation.test.mjs
+++ b/tests/config-loader-validation.test.mjs
@@ -75,6 +75,25 @@ describe('loadConfigResult', () => {
     assert.equal(config.events.needs_input.priority, 'urgent', 'default kept');
   });
 
+  it('idleReminderPriority is a known key validated on the same priority scale', () => {
+    fs.writeFileSync(configPath, JSON.stringify({
+      events: { needs_input: { idleReminderPriority: 'low' } },
+    }), 'utf8');
+    const { config, problem } = loadConfigResult(configPath);
+    assert.equal(problem, null, 'a valid idleReminderPriority is not a problem');
+    assert.equal(config.events.needs_input.idleReminderPriority, 'low');
+  });
+
+  it('invalid idleReminderPriority is rejected, leaving the downgrade default in force', () => {
+    fs.writeFileSync(configPath, JSON.stringify({
+      events: { needs_input: { idleReminderPriority: 'LOUD' } },
+    }), 'utf8');
+    const { config, problem } = loadConfigResult(configPath);
+    assert.match(problem.message, /"events\.needs_input\.idleReminderPriority" must be one of min\|low\|default\|high\|urgent/);
+    assert.equal(config.events.needs_input.idleReminderPriority, undefined, 'bad value dropped, router falls back to default');
+    assert.equal(config.events.needs_input.priority, 'urgent', 'real prompts still urgent');
+  });
+
   it('webhook: unknown keys are reported but kept', () => {
     fs.writeFileSync(configPath, JSON.stringify({
       webhook: { enabled: true, url: 'https://example.com/hook', foo: 'bar' },

--- a/tests/router.test.mjs
+++ b/tests/router.test.mjs
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { route } from '../src/router.mjs';
+import { deriveRichViews } from '../src/transcript.mjs';
 
 const defaultConfig = {
   events: {
@@ -59,5 +60,101 @@ describe('route', () => {
     const event = { source: 'claude', event: 'unknown', projectName: 'app' };
     const notif = route(event, defaultConfig);
     assert.equal(notif, null);
+  });
+});
+
+// Claude's ~60s idle nag arrives as a plain Notification and would otherwise
+// earn the urgent priority + alarm tags reserved for a real permission prompt.
+// The downgrade is volume-only, and every miss must fail toward LOUD.
+describe('route: claude idle "waiting for your input" reminder', () => {
+  const nag = (message, extra = {}) => ({
+    source: 'claude', event: 'needs_input', projectName: 'app', message, ...extra,
+  });
+  // The real copy Claude Code sends with the idle reminder.
+  const IDLE_TEXT = 'Claude is waiting for your input';
+  // What a genuine permission prompt looks like — no idle-nag substring.
+  const PROMPT_TEXT = 'Claude needs your permission to use Bash';
+
+  it('downgrades the nag to default priority with a calm tag', () => {
+    const notif = route(nag(IDLE_TEXT), defaultConfig);
+    assert.equal(notif.priority, 'default');
+    assert.equal(notif.ntfyTags, 'hourglass_flowing_sand');
+  });
+
+  it('matches the nag regardless of case', () => {
+    for (const text of [
+      IDLE_TEXT.toUpperCase(),
+      IDLE_TEXT.toLowerCase(),
+      'Claude Is WAITING For Your INPUT',
+    ]) {
+      assert.equal(route(nag(text), defaultConfig).priority, 'default', text);
+    }
+  });
+
+  it('leaves a real permission prompt byte-identical to today', () => {
+    const notif = route(nag(PROMPT_TEXT), defaultConfig);
+    assert.equal(notif.priority, 'urgent');
+    assert.equal(notif.ntfyTags, 'bell,warning');
+    assert.equal(notif.toastSound, 'Reminder');
+    assert.equal(notif.message, 'app: Needs your input');
+    // A prompt carrying no message at all (older Claude, other hooks) is the
+    // same untouched path.
+    const bare = route({ source: 'claude', event: 'needs_input', projectName: 'app' }, defaultConfig);
+    assert.deepEqual(bare, route({ source: 'claude', event: 'needs_input', projectName: 'app' }, defaultConfig));
+    assert.equal(bare.priority, 'urgent');
+    assert.equal(bare.ntfyTags, 'bell,warning');
+  });
+
+  it('stays URGENT if Claude changes its copy — drift fails toward loud', () => {
+    const notif = route(nag('Claude is idle and would like a response'), defaultConfig);
+    assert.equal(notif.priority, 'urgent');
+    assert.equal(notif.ntfyTags, 'bell,warning');
+  });
+
+  it('never fires for another source that happens to send the same text', () => {
+    for (const source of ['codex', 'gemini', 'cursor']) {
+      const notif = route(nag(IDLE_TEXT, { source }), defaultConfig);
+      assert.equal(notif.priority, 'urgent', source);
+      assert.equal(notif.ntfyTags, 'bell,warning', source);
+    }
+  });
+
+  it('never fires for a different event carrying the same text', () => {
+    const notif = route(nag(IDLE_TEXT, { event: 'task_complete' }), defaultConfig);
+    assert.equal(notif.priority, 'default');
+    assert.equal(notif.ntfyTags, 'white_check_mark', 'task_complete keeps its own tag');
+  });
+
+  it('tolerates a non-string message without downgrading', () => {
+    for (const message of [undefined, null, 42, { text: IDLE_TEXT }]) {
+      assert.equal(route(nag(message), defaultConfig).priority, 'urgent');
+    }
+  });
+
+  it('honors an explicit events.needs_input.idleReminderPriority', () => {
+    const config = {
+      ...defaultConfig,
+      events: {
+        ...defaultConfig.events,
+        needs_input: { ...defaultConfig.events.needs_input, idleReminderPriority: 'low' },
+      },
+    };
+    assert.equal(route(nag(IDLE_TEXT), config).priority, 'low');
+    // The override is nag-scoped: a real prompt still uses `priority`.
+    assert.equal(route(nag(PROMPT_TEXT), config).priority, 'urgent');
+  });
+
+  it('keeps the nag text as the rich body — the downgrade changes volume, not content', () => {
+    const config = {
+      ...defaultConfig,
+      toast: { enabled: true, richContent: true },
+      ntfy: { enabled: false },
+      webhook: { enabled: false },
+    };
+    const event = nag(IDLE_TEXT);
+    const notif = route(event, config);
+    const views = deriveRichViews(event, config, config.events.needs_input, notif, () => '');
+    assert.equal(views.toast.message, IDLE_TEXT);
+    assert.equal(views.toast.priority, 'default', 'rich view carries the downgraded priority');
   });
 });


### PR DESCRIPTION
## What

Claude's idle "waiting for your input" nag now pings at `default` priority with a calm `hourglass_flowing_sand` tag, instead of the urgent + `bell,warning` treatment reserved for real permission prompts. Never suppressed — only turned down.

## Why

Claude Code fires this Notification ~60s after a turn ends. Nobody is blocked and the work is done, but routed as a plain `needs_input` it earned the loudest ping the product can send — so every task the user walked away from ended in an urgent phone push reading "Claude is waiting for your input".

## How

- `router.mjs`: `isIdleReminder(event)` — claude + `needs_input` + case-insensitive substring match on Claude's own copy. **Drift fails toward loud**: if Claude ever changes the wording, the match fails and the nag stays urgent — a too-loud nag is an annoyance, a quiet permission prompt is a stalled agent. A real prompt never carries this text and is byte-identical to today (pinned).
- Volume only: channels, title, and rich body (the nag text) unchanged.
- Escape hatch: `events.needs_input.idleReminderPriority` (validated on the same ntfy 5-level scale via a shared `PRIORITY_KEYS` list; deliberately absent from default-config so only an explicit user value beats the downgrade).
- Parity note in-code: magent's state hook filters the identical substring but *drops* the event — persistent state vs one-shot ping justify different actions.

## Tests

11 new pins: downgrade + calm tag, case-insensitivity, real-prompt byte-identity (urgent + `bell,warning` + `Reminder` sound), copy-drift stays urgent, other sources/events with coincidental text untouched, non-string message untouched, `idleReminderPriority` honored, invalid value rejected on the shared scale, rich body still carries the nag text. Existing e2e `needs_input` pin unchanged (it exercises the no-message path — still a live guard on real prompts).

`npm test`: 436 tests, 428 pass, 0 fail (8 pre-existing platform skips).
