### PR TITLE
ci: run paid live Claude lanes on haiku + disable non-essential traffic

### DIFF
--- a/scripts/live-claude.mjs
+++ b/scripts/live-claude.mjs
@@ -26,8 +26,19 @@ async function main() {
   const home = setupIsolatedHomeWithToast({ prefix: 'aan-live-claude-', dir: '.claude', topic, seedSettingsFile: 'settings.json' });
   patchClaude(path.join(home, '.claude'), NOTIFY);
 
-  const env = { ...process.env, HOME: home, USERPROFILE: home };
-  const res = spawnSync('claude', ['-p', `Reply with exactly this token and nothing else: ${marker}`], {
+  // This lane bills a real key, so it runs on the cheapest model that proves the
+  // same thing: every assertion below is model-agnostic — any model can echo a
+  // token and fire the Stop hook — so haiku exercises the identical wiring.
+  // CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC additionally mutes the auto-updater,
+  // telemetry, error reporting, and the extra billed helper calls (e.g. haiku-powered
+  // summarization) that are pure cost here.
+  const env = {
+    ...process.env,
+    HOME: home,
+    USERPROFILE: home,
+    CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
+  };
+  const res = spawnSync('claude', ['--model', 'haiku', '-p', `Reply with exactly this token and nothing else: ${marker}`], {
     encoding: 'utf8', env, timeout: 120000,
   });
   console.log('claude exit:', res.status);

--- a/scripts/tui/proof-bell.mjs
+++ b/scripts/tui/proof-bell.mjs
@@ -100,7 +100,13 @@ async function main() {
   // `claude` and `node` (for the hook) resolve; we still pass claude's absolute
   // path for good measure.
   const claudeBin = resolveBin('claude');
-  const cmd = `env HOME='${home}' USERPROFILE='${home}' bash -c "cd '${workDir}' && exec '${claudeBin}'"`;
+  // This lane bills a real key, so it runs on the cheapest model that proves the
+  // same thing: the proof is model-agnostic — a completed turn fires the Stop hook
+  // → BEL → tmux bell flag regardless of which model answered.
+  // CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC additionally mutes the auto-updater,
+  // telemetry, error reporting, and the extra billed helper calls that are pure
+  // cost here. The interactive recipe itself is unchanged (pinned CLI, same keys).
+  const cmd = `env HOME='${home}' USERPROFILE='${home}' CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC='1' bash -c "cd '${workDir}' && exec '${claudeBin}' --model haiku"`;
   const win = newDetachedWindow(SESSION, cmd);
   console.log(`F1: agent window = ${SESSION}:${win} (claude bin: ${claudeBin})`);
 


### PR DESCRIPTION
## What

The two Anthropic-billed CI lanes now run on **haiku** instead of the default model, and both set `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`.

| File | Change |
|---|---|
| `scripts/live-claude.mjs` | `spawnSync('claude', ['--model', 'haiku', '-p', ...])`; env gains `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1'` |
| `scripts/tui/proof-bell.mjs` | tmux launch becomes `env HOME=… USERPROFILE=… CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC='1' bash -c "cd … && exec 'claude' --model haiku"` |

Not touched: `scripts/tui/proof-codex-approval.mjs` (OpenAI spend, different key), the `@anthropic-ai/claude-code@2.1.205` pin in both workflows, `package.json`, `CHANGELOG`.

## Why

These lanes burned default-model tokens to prove things that do not depend on the model at all:

- `live-claude.mjs` asserts the agent ran (exit 0 + non-empty stdout) and that the Stop hook delivered an ntfy push whose body is the **generic** router message. It deliberately does not assert on the nonce marker, so answer quality is irrelevant.
- `proof-bell.mjs` asserts a completed turn fires Stop → BEL → tmux `window_bell_flag`. Any model that finishes a turn rings the bell.

`CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` additionally mutes the auto-updater, telemetry, error reporting, and extra billed helper calls (e.g. haiku-powered summarization) that are pure cost in CI.

Net: roughly **10–20x cheaper** on these two lanes, with identical coverage.

## Validation

**a. `--model` exists on the exact pinned version** — `npx -y @anthropic-ai/claude-code@2.1.205 --help` (`--version` confirms `2.1.205 (Claude Code)`):

```
--model <model>    Model for the current session. Provide an alias for the
                   latest model (e.g. 'fable', 'opus', or 'sonnet') or a
                   model's full name (e.g. 'claude-fable-5').
```

Worth noting: that help text names only `fable`/`opus`/`sonnet`, **not** `haiku` — so the alias was smoke-tested rather than assumed.

**b. Print-mode smoke on the pinned version** (local auth, negligible cost):

```
$ npx -y @anthropic-ai/claude-code@2.1.205 --model haiku -p "Reply with exactly: SMOKE_OK"
SMOKE_OK                                                    # exit 0

$ CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 npx -y @anthropic-ai/claude-code@2.1.205 --model haiku -p "Reply with exactly: SMOKE_ENV_OK"
SMOKE_ENV_OK                                                # exit 0
```

The `haiku` alias resolves on 2.1.205 and the env var does not break the run — both in the exact `--model … -p …` shape `live-claude.mjs` uses.

**c. `npm test`** — `tests 425 | pass 417 | fail 0 | skipped 8`. No test drives a real `claude`, and no test references either changed script (`grep -rln "live-claude\|proof-bell" tests/` → no matches), so this is unchanged from main.

## Risk

The TUI bell lane's interactive recipe (keystrokes, timing, defensive re-submits at 20s/45s) is untouched, and the CLI stays pinned at 2.1.205 — the A/B-proven recipe is intact. The only behavioral difference is which model answers, and haiku turns complete faster, which if anything widens the bell lane's timing margin.

Neither paid lane can be exercised from a fork/local, so the first real proof is this PR's own CI run.
