### PR TITLE
ci: store workflow artifacts on self-hosted MinIO (DevinoSolutions/artifact)

### DIFF
--- a/.github/workflows/live-claude.yml
+++ b/.github/workflows/live-claude.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   live-claude:
+    permissions: write-all # GITHUB_TOKEN defaults + id-token for DevinoSolutions/artifact (OIDC)
     name: Live Claude E2E (required, paid)
     strategy:
       fail-fast: false
@@ -37,7 +38,7 @@ jobs:
         run: node scripts/live-claude.mjs
       - name: Diagnostics (always, macOS)
         if: always() && runner.os == 'macOS'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: DevinoSolutions/artifact/upload@v1
         with:
           name: live-claude-macos-diag
           path: ${{ runner.temp }}/diag

--- a/.github/workflows/live-gemini.yml
+++ b/.github/workflows/live-gemini.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   live-gemini:
+    permissions: write-all # GITHUB_TOKEN defaults + id-token for DevinoSolutions/artifact (OIDC)
     name: Live Gemini E2E (required)
     strategy:
       fail-fast: false
@@ -37,7 +38,7 @@ jobs:
         run: node scripts/live-gemini.mjs
       - name: Diagnostics (always, macOS)
         if: always() && runner.os == 'macOS'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: DevinoSolutions/artifact/upload@v1
         with:
           name: live-gemini-macos-diag
           path: ${{ runner.temp }}/diag

--- a/.github/workflows/toast-linux.yml
+++ b/.github/workflows/toast-linux.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   toast-linux:
+    permissions: write-all # GITHUB_TOKEN defaults + id-token for DevinoSolutions/artifact (OIDC)
     name: Live Toast Linux (notify-send → dunst capture)
     runs-on: ubuntu-latest
     steps:
@@ -48,7 +49,7 @@ jobs:
         run: xvfb-run -a dbus-run-session -- node scripts/live-toast-linux-render.mjs
       - name: Upload rendered banner (proof a human can see)
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: DevinoSolutions/artifact/upload@v1
         with:
           name: linux-render-proof
           path: /tmp/linux-render-proof

--- a/.github/workflows/toast-macos.yml
+++ b/.github/workflows/toast-macos.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   toast-macos:
+    permissions: write-all # GITHUB_TOKEN defaults + id-token for DevinoSolutions/artifact (OIDC)
     name: Live Toast macOS (delivery capture)
     runs-on: macos-15
     steps:
@@ -65,7 +66,7 @@ jobs:
 
       - name: Upload diagnostics
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: DevinoSolutions/artifact/upload@v1
         with:
           name: toast-macos-diagnostics
           path: /tmp/diag

--- a/.github/workflows/toast-native.yml
+++ b/.github/workflows/toast-native.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   toast-native:
+    permissions: write-all # GITHUB_TOKEN defaults + id-token for DevinoSolutions/artifact (OIDC)
     name: Live Toast Native (${{ matrix.os }})
     strategy:
       fail-fast: false
@@ -47,7 +48,7 @@ jobs:
 
       - name: Upload read-back evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: DevinoSolutions/artifact/upload@v1
         with:
           name: win-readback-proof
           path: ${{ runner.temp }}/win-readback-proof


### PR DESCRIPTION
Moves every `actions/upload-artifact` / `actions/download-artifact` step to
[`DevinoSolutions/artifact`](https://github.com/DevinoSolutions/artifact), a drop-in
replacement that stores artifacts on Devino's own MinIO (`storage.devino.ca`) instead
of GitHub's metered artifact storage.

**Why:** the org is on the free plan (500 MB artifact quota) with a $0 hard-stop Actions
budget, so once the quota is exceeded every artifact upload is rejected. Self-hosted
runners do not avoid this; the upstream action always writes to GitHub's blob store.

**What changed**
- `uses:` lines swapped to `DevinoSolutions/artifact/upload@v1` / `download@v1`; all inputs are compatible.
- Jobs that upload/download now request `id-token: write`, because the action authenticates to MinIO with the job's GitHub OIDC token (no secrets). Where a job had no `permissions` block, `permissions: write-all` is added, which equals the repo's current default token scopes plus `id-token`.
- `retention-days` is honoured via bucket lifecycle rules (rounded up to 1/3/5/7/14/30 days; anything above 30 keeps the 90-day default).

Artifacts are listed in each job's step summary as `s3://gh-artifacts/<owner>/<repo>/<run_id>/<name>.tgz` and can be fetched with `mc` or browsed at `minio-console.devino.ca`.
