### PR TITLE
feat: docs URL + single-source support link (CLI, README, package.json funding)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: DevinoSolutions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to `anotifier` are documented here. This project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
 
+## [Unreleased]
+
+### Added
+- **Documentation URL.** `anotifier --help` and the end of `anotifier setup` now
+  point at the full reference at `https://anotifier.io/docs/` instead of the
+  bare home page.
+- **Support link.** `package.json` carries the npm-standard `funding` field
+  (`npm fund` surfaces it), the repo has a `.github/FUNDING.yml`, and the CLI
+  prints a single muted line — "consider supporting it" — at the end of
+  `anotifier setup` and `anotifier status`, plus a footer line in `--help`. The
+  URL lives in exactly one place (`src/support.mjs` reads `funding.url`). It is
+  never printed on the hook path, never inside a notification, and never in
+  `doctor --json`.
+
 ## [1.2.6] — 2026-09-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@
 
 <p align="center">
   <a href="https://anotifier.io"><strong>anotifier.io</strong></a>
+  &nbsp;·&nbsp;
+  <a href="https://anotifier.io/docs/"><strong>Documentation</strong></a>
+  &nbsp;·&nbsp;
+  <a href="https://github.com/sponsors/DevinoSolutions"><strong>Support the project</strong></a>
 </p>
 
 <p align="center">
@@ -509,6 +513,10 @@ npm run toast:demo  # fire real desktop toasts, every event
 ### The one thing CI can't prove
 
 CI goes further than "the call returned 0." On **Linux** it reads the payload back out of a real `dunst` daemon **and** captures the X display to OCR the banner's text off the screen — pixels, not just a database row. On **macOS** it reads the delivery back out of Notification Center's own database, and on **Windows** out of the notification platform's `wpndatabase.db` — so a notification that was silently dropped for lack of permission records nothing and turns CI **red** instead of green. What no headless runner can prove is the last millimetre: a human's eyes actually seeing the banner. On macOS and Windows the on-screen banner can't be captured in CI at all (the hosted runner records the notification but never presents it — layer 2 is the ceiling ² ³), and everywhere Do Not Disturb / Focus can suppress the on-screen banner while the notification is still recorded as delivered. So "reached the notification store" is not always "a person saw it." To confirm with your own eyes — and to check your own machine's notification setup — run `npm run toast:demo` and `anotifier doctor --deep`. `--deep` fires a real test notification and reads it back where the OS allows: on **macOS** from Notification Center's database, on **Linux** from the `dunst` daemon's history (where `dunstctl` is present; other daemons honestly report dispatched-but-unverified). On **Windows**, `anotifier doctor` runs a static backend check (PowerShell + BurntToast + execution-policy).
+
+## Support the project
+
+anotifier is free, open source, and has no telemetry, no account, and no paid tier. It is built and maintained by [DevinoSolutions](https://github.com/DevinoSolutions). If it saves you time, consider supporting its development: **[github.com/sponsors/DevinoSolutions](https://github.com/sponsors/DevinoSolutions)**. The same link is printed once at the end of `anotifier setup` and `anotifier status`; it never appears in a notification or on the hook path.
 
 ## Contributing
 

--- a/cli/index.mjs
+++ b/cli/index.mjs
@@ -2,6 +2,7 @@
 // cli/index.mjs
 import { createRequire } from 'node:module';
 import { checkForUpdate, isNewer } from '../src/update-check.mjs';
+import { DOCS_URL, SUPPORT_URL } from '../src/support.mjs';
 
 const require = createRequire(import.meta.url);
 const pkg = require('../package.json');
@@ -90,7 +91,8 @@ function printHelp(c, banner) {
   console.log(`    ${c.muted('$')} ${c.white('anotifier test toast')}`);
   console.log(`    ${c.muted('$')} ${c.white('anotifier config ntfy')}`);
   console.log();
-  console.log(`  ${c.muted('Docs & guides:')} ${c.accent('https://anotifier.io')}`);
+  console.log(`  ${c.muted('Docs & guides:')} ${c.accent(DOCS_URL)}`);
+  console.log(`  ${c.muted('Support the project:')} ${c.accent(SUPPORT_URL)}`);
   console.log();
 }
 

--- a/cli/setup.mjs
+++ b/cli/setup.mjs
@@ -8,6 +8,7 @@ import { execSync } from 'node:child_process';
 import { getConfigDir, getConfigPath, loadConfigResult, saveConfig } from '../src/config-loader.mjs';
 import { patchClaude, patchCodex, patchCursor, patchGemini } from '../setup/patch-config.mjs';
 import { ask, askYN, log } from './ui.mjs';
+import { DOCS_URL, SUPPORT_LINE } from '../src/support.mjs';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -259,7 +260,10 @@ export async function run() {
 
   // 9. Summary — only reached when every detected tool patched cleanly.
   log('\n  ✓ Setup complete. Restart your AI tools to activate.', 'green');
-  log('    Docs & guides: https://anotifier.io\n', 'dim');
+  log(`    Docs & guides: ${DOCS_URL}`, 'dim');
+  // The only place besides `status` where we ask for support — interactive
+  // CLI output only, never the hook path and never inside a notification.
+  log(`    ${SUPPORT_LINE}\n`, 'dim');
 
   rl.close();
 }

--- a/cli/status.mjs
+++ b/cli/status.mjs
@@ -8,6 +8,7 @@ import { readRecentHookErrors, getErrorLogPath } from '../src/error-log.mjs';
 import { detectManagedEvents } from '../setup/patch-config.mjs';
 import { checkForUpdate, isNewer } from '../src/update-check.mjs';
 import { readSnoozeUntil, quietHoursWindow, inQuietHours, formatClock } from '../src/suppress.mjs';
+import { SUPPORT_LINE } from '../src/support.mjs';
 import { c, box, kv, sectionHeader } from './ui.mjs';
 
 const require = createRequire(import.meta.url);
@@ -141,5 +142,9 @@ export async function run() {
     console.log(`  ${c.warn('↑')} ${c.warn(`Update available: v${pkg.version} → v${latest}`)}`);
     console.log(`    ${c.muted('npm i -g anotifier@latest')}`);
   }
+
+  // Gentle, one-line ask at the very end of the command people run most.
+  console.log();
+  console.log(`  ${c.muted(SUPPORT_LINE)}`);
   console.log();
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,10 @@
     "url": "git+https://github.com/DevinoSolutions/anotifier-for-claude-codex-cursor.git"
   },
   "homepage": "https://anotifier.io",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/DevinoSolutions"
+  },
   "license": "AGPL-3.0-or-later",
   "engines": {
     "node": ">=18.0.0"

--- a/src/support.mjs
+++ b/src/support.mjs
@@ -1,0 +1,18 @@
+// src/support.mjs — the ONE place the project's outbound "where to go" URLs live.
+//
+// SUPPORT_URL is read from package.json `funding.url` (the npm-standard field
+// that `npm fund` also surfaces), so changing the sponsorship destination is a
+// single package.json edit — the CLI, README badge and FUNDING.yml all follow.
+// These are only ever printed by interactive CLI commands, never on the hook
+// path and never inside a notification.
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const pkg = require('../package.json');
+
+export const SUPPORT_URL = pkg.funding?.url ?? 'https://github.com/sponsors/DevinoSolutions';
+export const DOCS_URL = 'https://anotifier.io/docs/';
+
+// One sentence, reused verbatim by setup and status so the ask reads the same
+// everywhere and stays easy to grep for.
+export const SUPPORT_LINE = `♥ anotifier is free & open source. If it saves you time, consider supporting it: ${SUPPORT_URL}`;

--- a/tests/cli-support-line.test.mjs
+++ b/tests/cli-support-line.test.mjs
@@ -1,0 +1,73 @@
+// tests/cli-support-line.test.mjs — where the support/docs URLs may and may NOT
+// appear. Spawns the real CLI (offline: a fresh seeded update cache means no
+// registry request) and asserts:
+//   --help          → both the docs URL and the support URL
+//   status          → the support line, once, at the end
+//   doctor --json   → neither (stdout must stay valid JSON)
+// The hook path (src/notify.mjs) is covered separately: it must never print them.
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { SUPPORT_URL, DOCS_URL } from '../src/support.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function runCli(args) {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'aan-support-'));
+  const cfgDir = path.join(home, '.anotifier');
+  fs.mkdirSync(cfgDir, { recursive: true });
+  // Fresh cache → served from disk, no network.
+  fs.writeFileSync(path.join(cfgDir, '.update-check.json'), JSON.stringify({ checkedAt: Date.now(), latest: null }));
+  const res = spawnSync(process.execPath, ['cli/index.mjs', ...args], {
+    cwd: repoRoot,
+    env: { ...process.env, HOME: home, USERPROFILE: home, NO_COLOR: '1' },
+    encoding: 'utf8',
+    timeout: 30000,
+  });
+  fs.rmSync(home, { recursive: true, force: true });
+  return { status: res.status, stdout: res.stdout || '', stderr: res.stderr || '' };
+}
+
+const count = (hay, needle) => hay.split(needle).length - 1;
+
+describe('support & docs URLs in CLI output', () => {
+  it('--help prints the docs URL and the support URL', () => {
+    const res = runCli(['--help']);
+    assert.equal(res.status, 0, res.stderr);
+    assert.ok(res.stdout.includes(DOCS_URL), `missing docs URL:\n${res.stdout}`);
+    assert.ok(res.stdout.includes(SUPPORT_URL), `missing support URL:\n${res.stdout}`);
+  });
+
+  it('status ends with exactly one support line', () => {
+    const res = runCli(['status']);
+    assert.equal(res.status, 0, res.stderr);
+    assert.equal(count(res.stdout, SUPPORT_URL), 1, res.stdout);
+    assert.match(res.stdout, /consider supporting/i);
+    // "at the end": nothing but whitespace (and ANSI resets — ui.mjs colors
+    // regardless of NO_COLOR) follows the support line.
+    const plain = res.stdout.replace(/\x1b\[[0-9;]*m/g, '');
+    const after = plain.slice(plain.indexOf(SUPPORT_URL) + SUPPORT_URL.length);
+    assert.equal(after.trim(), '', `support line must be last, got trailing: ${JSON.stringify(after)}`);
+  });
+
+  it('doctor --json stays machine-parseable and carries neither URL', () => {
+    const res = runCli(['doctor', '--json']);
+    // doctor exits 1 when a check fails (e.g. ntfy unconfigured is only a warn,
+    // but a missing backend on a bare runner can fail) — parseability is the
+    // contract here, not the exit code.
+    const parsed = JSON.parse(res.stdout);
+    assert.ok(Array.isArray(parsed.checks));
+    assert.ok(!res.stdout.includes(SUPPORT_URL), res.stdout);
+    assert.ok(!res.stdout.includes(DOCS_URL), res.stdout);
+  });
+
+  it('the hook path never imports or prints the support line', () => {
+    const notify = fs.readFileSync(path.join(repoRoot, 'src', 'notify.mjs'), 'utf8');
+    assert.ok(!notify.includes('support.mjs'), 'src/notify.mjs must not import src/support.mjs');
+    assert.ok(!notify.includes('sponsors/'), 'src/notify.mjs must not mention sponsorship');
+  });
+});

--- a/tests/support.test.mjs
+++ b/tests/support.test.mjs
@@ -1,0 +1,44 @@
+// tests/support.test.mjs — the support/docs URLs have exactly one home.
+//
+// SUPPORT_URL must be the package.json `funding.url` (npm's own field, so
+// `npm fund` and the CLI can never disagree), and both URLs must be real https
+// URLs — a typo here would ship a dead link in every `setup` run.
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SUPPORT_URL, DOCS_URL, SUPPORT_LINE } from '../src/support.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(fs.readFileSync(path.join(here, '..', 'package.json'), 'utf8'));
+
+describe('src/support.mjs', () => {
+  it('SUPPORT_URL is exactly package.json funding.url', () => {
+    assert.equal(typeof pkg.funding?.url, 'string', 'package.json must declare funding.url');
+    assert.equal(SUPPORT_URL, pkg.funding.url);
+  });
+
+  it('both URLs are valid https URLs', () => {
+    for (const url of [SUPPORT_URL, DOCS_URL]) {
+      const u = new URL(url); // throws on garbage
+      assert.equal(u.protocol, 'https:', url);
+      assert.ok(u.hostname.includes('.'), url);
+    }
+  });
+
+  it('DOCS_URL points at the anotifier.io docs page', () => {
+    assert.equal(DOCS_URL, 'https://anotifier.io/docs/');
+  });
+
+  it('SUPPORT_LINE asks gently and carries the URL verbatim', () => {
+    assert.ok(SUPPORT_LINE.includes(SUPPORT_URL));
+    assert.match(SUPPORT_LINE, /consider supporting/i);
+    assert.ok(!/\n/.test(SUPPORT_LINE), 'single line');
+  });
+
+  it('the sponsorship destination is the DevinoSolutions GitHub Sponsors page', () => {
+    // If this ever changes, package.json funding.url is the one place to edit.
+    assert.equal(SUPPORT_URL, 'https://github.com/sponsors/DevinoSolutions');
+  });
+});


### PR DESCRIPTION
## What
- `package.json` gains the npm-standard `funding` field → `https://github.com/sponsors/DevinoSolutions`. `src/support.mjs` reads it, so the sponsorship destination has exactly one home (`SUPPORT_URL`), alongside `DOCS_URL = https://anotifier.io/docs/`.
- CLI, interactive output only:
  - `anotifier --help` footer: docs URL + "Support the project" URL
  - end of `anotifier setup`: docs URL + one muted "consider supporting it" line
  - end of `anotifier status`: the same single line
  - **not** in `doctor --json` (stays valid JSON), **never** on the hook path or inside a notification
- `.github/FUNDING.yml` (`github: DevinoSolutions`)
- README: "Documentation" link next to the site link; short "Support the project" section before Contributing
- CHANGELOG: `## [Unreleased]` → `### Added` (verified `scripts/extract-changelog.mjs` treats it as a heading boundary, so 1.2.6 extraction is unaffected)

## Tests
- `tests/support.test.mjs` — `SUPPORT_URL === package.json funding.url`, both URLs valid https, single-line ask
- `tests/cli-support-line.test.mjs` — spawns the real CLI offline (seeded fresh update cache): help prints both URLs; status ends with exactly one support line; `doctor --json` parses and carries neither; `src/notify.mjs` never imports/mentions it
- `npm test`: 452 tests, 444 pass, 8 skipped (live-gated), 0 fail

## Note
GitHub Sponsors for DevinoSolutions is not enrolled yet; the URL currently redirects to the org profile. Copy says "consider supporting", never "live". Activating Sponsors is a maintainer action; no code change needed afterwards.
