### PR TITLE
chore: track anotifier-landing as a git submodule at ./landing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "landing"]
+	path = landing
+	url = https://github.com/DevinoSolutions/anotifier-landing.git

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,1 +1,2 @@
 assets/icons/
+landing/


### PR DESCRIPTION
Pins the private landing repo (anotifier.io) at `landing/` → `a6d7024` (the commit that adds /docs, /guides, /compare and the ♥ Support link for 1.2.6).

- `.gitmodules` uses the https URL; contributors without org access simply can't `--init` it, nothing else changes.
- `npm pack --dry-run` lists nothing under `landing/` (the `files` whitelist already excludes it).
- No workflow opts into `submodules:` on checkout, so CI is unaffected.
- `landing/` added to `.graphifyignore`.

Bump the pointer when the site changes: `cd landing && git pull && cd .. && git add landing`.